### PR TITLE
Mod Map + Map Center Constraints

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -16,10 +16,9 @@
     padding: 0;
 }
 
-body {
-    /* background: url('../../public/background.svg') rgba(255, 255, 255, 0.15) center no-repeat fixed;
-    background-size: cover; */
-    /* background-color: #EBF1ED; */
+/* remove leaflet attribution control */
+.leaflet-control-attribution {
+  display: none !important;
 }
 
 .seller_item_container{

--- a/src/components/shared/map/Map.tsx
+++ b/src/components/shared/map/Map.tsx
@@ -23,11 +23,8 @@ const fetchSellerCoordinates = async (origin: LatLngTuple, radius: number): Prom
   const { lat, lng } = sanitizeCoordinates(origin[0], origin[1]);
   const formattedOrigin = toLatLngLiteral([lat, lng]);
 
-  console.log('Fetching seller coordinates with origin:', JSON.stringify(formattedOrigin), 'and radius:', radius);
-
   try {
     const sellersData = await fetchSellers(formattedOrigin, radius);
-
     const sellersWithCoordinates = sellersData.map((seller: any) => {
       const [lng, lat] = seller.sell_map_center.coordinates;
       return {
@@ -229,6 +226,12 @@ const Map = ({ center, zoom }: { center: LatLngExpression, zoom: number }) => {
     );
   }
 
+  // define map boundaries
+  const bounds = L.latLngBounds(
+    L.latLng(-90, -180), // SW corner
+    L.latLng(90, 180)  // NE corner
+  );
+
   return (
     <>
       {loading && <div className="loading">Loading...</div>}
@@ -257,10 +260,15 @@ const Map = ({ center, zoom }: { center: LatLngExpression, zoom: number }) => {
         center={isLocationAvailable ? origin : [0, 0]}
         zoom={isLocationAvailable ? zoom : 2}
         zoomControl={false}
+        minZoom={2}
+        maxZoom={18}
+        maxBounds={bounds}
+        maxBoundsViscosity={1.0}
         className="w-full flex-1 fixed bottom-0 h-[calc(100vh-76.19px)] left-0 right-0">
         <TileLayer
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          noWrap={true}
         />
         <LocationMarker />
         {sellers.map((seller) => (

--- a/src/components/shared/map/MapCenter.tsx
+++ b/src/components/shared/map/MapCenter.tsx
@@ -26,13 +26,6 @@ const crosshairIcon = new L.Icon({
   iconAnchor: [40, 40],
 });
 
-// Define the pin icon for the saved location
-const pinIcon = new L.Icon({
-  iconUrl: '/images/icons/map_of_pi_logo.jpeg',
-  iconSize: [32, 32],
-  iconAnchor: [16, 32],
-});
-
 const MapCenter = () => {
   const t = useTranslations();
 
@@ -92,17 +85,28 @@ const MapCenter = () => {
     setShowPopup(false);
   };
 
+  // define map boundaries
+  const bounds = L.latLngBounds(
+    L.latLng(-90, -180), // SW corner
+    L.latLng(90, 180)  // NE corner
+  );
+
   return (
     <div>
       <MapContainer
-        zoomControl={false}
         center={center}
-        zoom={13}
+        zoom={2}
+        zoomControl={false}
+        minZoom={2}
+        maxZoom={18}
+        maxBounds={bounds}
+        maxBoundsViscosity={1.0}
         className="w-full flex-1 fixed top-[76.19px] h-[calc(100vh-76.19px)] left-0 right-0 bottom-0"
       >
         <TileLayer
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           attribution="Map data © OpenStreetMap contributors"
+          noWrap={true}
         />
         <CenterMarker />
         <RecenterAutomatically position={center} />


### PR DESCRIPTION
Addresses the following tasks - 
- Landing page: Limit map boundaries for zooming out. Max zoom out should be ONE whole world only
- Landing page, map: remove (c)OpenStreetMap notice from bottom of screen

Screenshot [_not sandbox_]

![image](https://github.com/user-attachments/assets/a6f87b12-b0b0-47fc-b9c6-7e83efdf23ed)





**[see commits]**