### PR TITLE
Feature/email phone userprfs

### DIFF
--- a/src/components/shared/sidebar/sidebar.tsx
+++ b/src/components/shared/sidebar/sidebar.tsx
@@ -57,14 +57,24 @@ function Sidebar(props: any) {
 
   const { currentUser, autoLoginUser } = useContext(AppContext);
   const [dbUserSettings, setDbUserSettings] = useState<IUserSettings | null>(null);
-  const [formData, setFormData] = useState({
+
+  // Initialize state with appropriate types
+  const [formData, setFormData] = useState<{
+    user_name: string;
+    email: string | null;
+    phone_number: string | null;
+    image: string;
+    findme: string;
+    trust_meter_rating: number;
+  }>({
     user_name: '',
-    email: '',
-    phone_number: '',
+    email: null,
+    phone_number: null,
     image: '',
     findme: 'auto',
     trust_meter_rating: 100,
   });
+
   const { resolvedTheme, setTheme } = useTheme();
   const [toggle, setToggle] = useState<any>({
     Themes: false,
@@ -107,8 +117,8 @@ function Sidebar(props: any) {
     if (dbUserSettings) {
       setFormData({
         user_name: dbUserSettings.user_name || '',
-        email: dbUserSettings.email || '',
-        phone_number: dbUserSettings.phone_number?.toString() || '',
+        email: dbUserSettings.email || null,
+        phone_number: dbUserSettings.phone_number?.toString() || null,
         image: dbUserSettings.image || '',
         findme: dbUserSettings.findme || translateFindMeOptions[0].value,
         trust_meter_rating: dbUserSettings.trust_meter_rating
@@ -227,8 +237,8 @@ function Sidebar(props: any) {
 
     const formDataToSend = new FormData();
     formDataToSend.append('user_name', formData.user_name);
-    formDataToSend.append('email', formData.email);
-    formDataToSend.append('phone_number', formData.phone_number);
+    formDataToSend.append('email', formData.email ?? '');
+    formDataToSend.append('phone_number', formData.phone_number ?? '');
     formDataToSend.append('findme', formData.findme);
 
     // add the image if it exists

--- a/src/components/shared/sidebar/sidebar.tsx
+++ b/src/components/shared/sidebar/sidebar.tsx
@@ -348,26 +348,6 @@ function Sidebar(props: any) {
               value={formData.user_name? formData.user_name: ''}
               onChange={handleChange}
             />
-            <Input
-              label={t('SIDE_NAVIGATION.EMAIL_ADDRESS_FIELD')}
-              placeholder="mapofpi@mapofpi.com"
-              type="email"
-              name="email"
-              style={{
-                textAlign: 'center'
-              }}
-              value={formData.email? formData.email: ""}
-              onChange={handleChange}
-            />
-            <TelephoneInput
-              label={t('SIDE_NAVIGATION.PHONE_NUMBER_FIELD')}
-              value={formData.phone_number}
-              name="phone_number"
-              onChange={(value: any) => handleChange({ name: 'phone_number', value })}
-              style={{
-                textAlign: 'center'
-              }}
-            />
 
             <Button
               label={t('SHARED.SAVE')}

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -7,8 +7,8 @@ export interface IUser {
 export interface IUserSettings {
   user_settings_id?: string | null;
   user_name?: string;
-  email?: string;
-  phone_number?: string;
+  email?: string | null;
+  phone_number?: string | null;
   image?: string; 
   findme?: string;
   trust_meter_rating: number;


### PR DESCRIPTION
We updated the frontend to remove the display of email and phone number fields.

The email and phone number are no longer shown in the user interface on the seller items screen and user preference screen (sideBar). These fields are now initialized as null.