### PR TITLE
Feature/email phone seller reg

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -40,6 +40,10 @@
     "SELLER_REGISTRATION": {
       "SELLER_REGISTRATION_HEADER": "Seller Registration",
       "SELLER_DETAILS_LABEL": "Seller Details",
+      "EMAIL_LABEL": "Your email address",
+      "PHONE_NUMBER_LABEL": "Your phone number",
+      "EMAIL_PUBLIC_NOTE": "Note: Your email address will be publicly visible.",
+      "PHONE_PUBLIC_NOTE": "Note: Your phone number will be publicly visible.",
       "SELLER_DETAILS_PLACEHOLDER": "Description of seller & items for sale with pi price, etc.",
       "REVIEWS_SUMMARY_LABEL": "Reviews Summary",
       "REVIEWS_SCORE_LABEL": "Reviews Score",

--- a/src/app/[locale]/seller/registration/page.tsx
+++ b/src/app/[locale]/seller/registration/page.tsx
@@ -40,6 +40,8 @@ const SellerRegistrationForm = () => {
     sellerType: 'testSeller',
     sellerDescription: '',
     sellerAddress: '',
+    email: '',
+    phone_number: '',
     image: ''
   });
   const [dbSeller, setDbSeller] = useState<ISeller | null>(null);
@@ -100,6 +102,8 @@ const SellerRegistrationForm = () => {
         sellerAddress: dbSeller.address || '',
         sellerType: dbSeller.seller_type || translatedSellerTypeOptions[2].value,
         image: dbSeller.image || ''
+        email: dbSeller.email || '',
+        phone_number: dbSeller.phone_number || '',
       });
     }
   }, [dbSeller]);
@@ -198,6 +202,8 @@ const SellerRegistrationForm = () => {
     formDataToSend.append('seller_type', formData.sellerType);
     formDataToSend.append('description', sellerDescription);
     formDataToSend.append('address', sellerAddress);
+    formDataToSend.append('email', formData.email);
+    formDataToSend.append('phone_number', formData.phone_number );
     // hardcode the value until the form element is built
     formDataToSend.append('order_online_enabled_pref', 'false');
 

--- a/src/app/[locale]/seller/registration/page.tsx
+++ b/src/app/[locale]/seller/registration/page.tsx
@@ -101,7 +101,7 @@ const SellerRegistrationForm = () => {
         sellerDescription: dbSeller.description || '',
         sellerAddress: dbSeller.address || '',
         sellerType: dbSeller.seller_type || translatedSellerTypeOptions[2].value,
-        image: dbSeller.image || ''
+        image: dbSeller.image || '',
         email: dbSeller.email || '',
         phone_number: dbSeller.phone_number || '',
       });
@@ -334,6 +334,38 @@ const SellerRegistrationForm = () => {
                 onChange={handleChange}
                 options={translatedSellerTypeOptions}
               />
+
+              <div className="mb-4">
+                <label>
+                  {t('SCREEN.SELLER_REGISTRATION.EMAIL_LABEL')}
+                </label>
+                <p className="text-gray-400 text-sm mt-1">
+                  {t('SCREEN.SELLER_REGISTRATION.EMAIL_PUBLIC_NOTE')}
+                </p>
+                <Input
+                  name="email"
+                  type="text"
+                  value={formData.email}
+                  onChange={handleChange}
+                />
+              </div>
+
+              <div className="mb-4">
+                {/* Phone input */}
+                <label>
+                  {t('SCREEN.SELLER_REGISTRATION.PHONE_NUMBER_LABEL')}
+                </label>
+                <p className="text-gray-400 text-sm mt-1"> {/* Note directly below the label */}
+                  {t('SCREEN.SELLER_REGISTRATION.PHONE_PUBLIC_NOTE')}
+                </p>
+                <Input
+                  name="phone_number"
+                  type="text"
+                  value={formData.phone_number}
+                  onChange={handleChange}
+                />
+              </div>
+
               <TextArea
                 label={t('SCREEN.SELLER_REGISTRATION.SELLER_ADDRESS_LOCATION_LABEL')}
                 describe={t('SCREEN.SELLER_REGISTRATION.SELLER_ADDRESS_LOCATION_PLACEHOLDER')}
@@ -410,13 +442,11 @@ const SellerRegistrationForm = () => {
               <span className="font-bold">
                 {t('SHARED.USER_INFORMATION.PHONE_NUMBER_LABEL') + ': '}
               </span>
-              <span>{userSettings ? userSettings.phone_number : ""}</span>
             </div>
             <div className="text-sm mb-5">
               <span className="font-bold">
                 {t('SHARED.USER_INFORMATION.EMAIL_LABEL') + ': '}
               </span>
-              <span>{ userSettings ? userSettings.email : ""}</span>
             </div>
             <div className="mb-4 mt-3 ml-auto w-min">
               <Button

--- a/src/components/shared/sidebar/sidebar.tsx
+++ b/src/components/shared/sidebar/sidebar.tsx
@@ -60,8 +60,6 @@ function Sidebar(props: any) {
   const [dbUserSettings, setDbUserSettings] = useState<IUserSettings | null>(null);
   const [formData, setFormData] = useState({
     user_name: '',
-    email: '',
-    phone_number: '',
     image: '',
     findme: 'auto',
     trust_meter_rating: 100,
@@ -108,8 +106,6 @@ function Sidebar(props: any) {
     if (dbUserSettings) {
       setFormData({
         user_name: dbUserSettings.user_name || '',
-        email: dbUserSettings.email || '',
-        phone_number: dbUserSettings.phone_number?.toString() || '',
         image: dbUserSettings.image || '',
         findme: dbUserSettings.findme || translateFindMeOptions[0].value,
         trust_meter_rating: dbUserSettings.trust_meter_rating
@@ -228,8 +224,6 @@ function Sidebar(props: any) {
 
     const formDataToSend = new FormData();
     formDataToSend.append('user_name', removeUrls(formData.user_name));
-    formDataToSend.append('email', formData.email);
-    formDataToSend.append('phone_number', formData.phone_number);
     formDataToSend.append('findme', formData.findme);
 
     // add the image if it exists
@@ -348,26 +342,6 @@ function Sidebar(props: any) {
               }}
               value={formData.user_name? formData.user_name: ''}
               onChange={handleChange}
-            />
-            <Input
-              label={t('SIDE_NAVIGATION.EMAIL_ADDRESS_FIELD')}
-              placeholder="mapofpi@mapofpi.com"
-              type="email"
-              name="email"
-              style={{
-                textAlign: 'center'
-              }}
-              value={formData.email? formData.email: ""}
-              onChange={handleChange}
-            />
-            <TelephoneInput
-              label={t('SIDE_NAVIGATION.PHONE_NUMBER_FIELD')}
-              value={formData.phone_number}
-              name="phone_number"
-              onChange={(value: any) => handleChange({ name: 'phone_number', value })}
-              style={{
-                textAlign: 'center'
-              }}
             />
 
             <Button

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -7,8 +7,6 @@ export interface IUser {
 export interface IUserSettings {
   user_settings_id?: string | null;
   user_name?: string;
-  email?: string;
-  phone_number?: string;
   image?: string; 
   findme?: string;
   trust_meter_rating: number;
@@ -23,6 +21,8 @@ export interface ISeller {
   name: string;
   description: string;
   seller_type: string;
+  email?: string | null;
+  phone_number?: string | null;
   image: string;
   address: string;
   average_rating: {
@@ -49,7 +49,7 @@ export interface IReviewFeedback {
 }
 
 // Select specific fields from IUserSettings
-export type PartialUserSettings = Pick<IUserSettings, 'user_name' | 'email' | 'phone_number' | 'findme' | 'trust_meter_rating'>;
+export type PartialUserSettings = Pick<IUserSettings, 'user_name' | 'findme' | 'trust_meter_rating'>;
 
 // Combined interface representing a seller with selected user settings
 export interface ISellerWithSettings extends ISeller, PartialUserSettings {}


### PR DESCRIPTION
In this PR, we added email and phone number fields to the Seller Registration form. This includes updating the interface, handling these fields in the form logic, and making them visible in the UI with proper labels and notes. We also removed any old references to email and phone from other parts of the app.