### PR TITLE
fix: add map center to form data

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/app/[locale]/seller/registration/page.tsx
+++ b/src/app/[locale]/seller/registration/page.tsx
@@ -77,6 +77,7 @@ const SellerRegistrationForm = () => {
     const getSellerData = async () => {
       try {
         const data = await fetchSellerRegistration();
+        logger.info(`seller data ${JSON.stringify(data)}`);
         if (data) {
           setDbSeller(data);
         } else {
@@ -229,6 +230,8 @@ const SellerRegistrationForm = () => {
     // hardcode the value until the form element is built
     formDataToSend.append('order_online_enabled_pref', 'false');
 
+    const mapCenter = dbSeller?.sell_map_center || dbUserSettings?.search_map_center;
+    formDataToSend.append('sell_map_center', JSON.stringify(mapCenter));
     // Add the image if it exists
     if (file) {
       formDataToSend.append('image', file);


### PR DESCRIPTION
add sell map center to formdata when submitting data to backend server. 
if user did not set sell center, this will default to the search center of the user. 