### PR TITLE
fix: default sell center values

### DIFF
--- a/src/app/[locale]/seller/registration/page.tsx
+++ b/src/app/[locale]/seller/registration/page.tsx
@@ -229,6 +229,8 @@ const SellerRegistrationForm = () => {
     // hardcode the value until the form element is built
     formDataToSend.append('order_online_enabled_pref', 'false');
 
+    const mapCenter = dbSeller?.sell_map_center || dbUserSettings?.search_map_center;
+    formDataToSend.append('sell_map_center', JSON.stringify(mapCenter));
     // Add the image if it exists
     if (file) {
       formDataToSend.append('image', file);


### PR DESCRIPTION
seller registration map center data will now default to search center when none is available