### PR TITLE
fix: markers not showing on page load

### DIFF
--- a/src/components/shared/map/Map.tsx
+++ b/src/components/shared/map/Map.tsx
@@ -168,13 +168,15 @@ const Map = ({
     setError(null);
     try {
       // Fetch the current map bounds
-      const bounds = mapRef.current?.getBounds();
+      // manually set bounds as mapref is null during component rendering phase
+      const bounds = L.latLngBounds(
+        L.latLng(-90, -180),
+        L.latLng(90, 180)
+      );
 
-      if (bounds) {
-        let sellersData = await fetchSellerCoordinates(bounds, '');
-        sellersData = removeDuplicates(sellersData);
-        setSellers(sellersData);
-      }
+      let sellersData = await fetchSellerCoordinates(bounds, '');
+      sellersData = removeDuplicates(sellersData);
+      setSellers(sellersData);
     } catch (error) {
       logger.error('Failed to fetch initial coordinates:', { error });
       setError('Failed to fetch initial coordinates');


### PR DESCRIPTION
manually create map bounds used for fetching the sellers on initial page load as `mapref` is null when code inside useEffect is run. 