### PR TITLE
Fix markers not displaying on initial map load by fetching sellers af…

### DIFF
--- a/src/components/shared/map/Map.tsx
+++ b/src/components/shared/map/Map.tsx
@@ -338,8 +338,7 @@ const Map = ({
           minZoom={2}
           maxZoom={18}
           whenReady={(mapInstance) => {
-            mapRef.current = mapInstance.target;
-            fetchInitialCoordinates(); // Fetch sellers after the map is initialized
+            mapRef.current = mapInstance.target; // Set mapRef correctly
           }}
           className="w-full flex-1 fixed bottom-0 h-[calc(100vh-76.19px)] left-0 right-0"
         >

--- a/src/components/shared/map/Map.tsx
+++ b/src/components/shared/map/Map.tsx
@@ -154,6 +154,12 @@ const Map = ({
     map.panBy(panOffset, { animate: false }); // Disable animation to make the movement instant
   };
 
+  useEffect(() => {
+    if (mapRef.current) {
+      fetchInitialCoordinates();  // Fetch sellers when map is ready
+    }
+  }, [mapRef.current]);
+
   const fetchInitialCoordinates = async () => {
     if (searchQuery) return;
   
@@ -333,12 +339,9 @@ const Map = ({
           zoomControl={false}
           minZoom={2}
           maxZoom={18}
-          whenReady={() => {
-            if (mapRef.current) {
-              fetchInitialCoordinates(); // Fetch sellers now that mapRef is ready
-            }
+          whenReady={(mapInstance) => {
+            mapRef.current = mapInstance;        // Fetch sellers now that mapRef is ready
           }}
-          ref={mapRef}
           className="w-full flex-1 fixed bottom-0 h-[calc(100vh-76.19px)] left-0 right-0"
         >
           <TileLayer

--- a/src/components/shared/map/Map.tsx
+++ b/src/components/shared/map/Map.tsx
@@ -337,9 +337,9 @@ const Map = ({
           zoomControl={false}
           minZoom={2}
           maxZoom={18}
-          whenReady={(event) => {
-            mapRef.current = event.target; // Set mapRef.current
-            fetchInitialCoordinates();     // Fetch sellers now that mapRef is ready
+          whenReady={(mapInstance) => {
+            mapRef.current = mapInstance.target;
+            fetchInitialCoordinates(); // Fetch sellers after the map is initialized
           }}
           className="w-full flex-1 fixed bottom-0 h-[calc(100vh-76.19px)] left-0 right-0"
         >

--- a/src/components/shared/map/Map.tsx
+++ b/src/components/shared/map/Map.tsx
@@ -154,27 +154,21 @@ const Map = ({
     map.panBy(panOffset, { animate: false }); // Disable animation to make the movement instant
   };
 
-  // Function to fetch initial coordinates
   const fetchInitialCoordinates = async () => {
     if (searchQuery) return;
-    
+  
     setLoading(true);
     setError(null);
   
     try {
-      const mapInstance = mapRef.current;
+      const mapInstance = mapRef.current; // Access map instance via ref
   
       if (!mapInstance) {
         logger.warn('Map instance is not ready yet');
         return;
       }
   
-      logger.info('Map instance:', mapInstance);
-  
-      // Fetch the bounds using mapInstance.target.getBounds()
       const bounds = mapInstance.getBounds();
-      logger.info('Fetched map bounds:', bounds); // Debug log for bounds
-  
       if (bounds) {
         let sellersData = await fetchSellerCoordinates(bounds, '');
         sellersData = removeDuplicates(sellersData);
@@ -339,10 +333,12 @@ const Map = ({
           zoomControl={false}
           minZoom={2}
           maxZoom={18}
-          whenReady={(mapInstance: any) => {
-            mapRef.current = mapInstance.target; // Use mapInstance.target as the actual map object
-            fetchInitialCoordinates();        // Fetch sellers now that mapRef is ready
+          whenReady={() => {
+            if (mapRef.current) {
+              fetchInitialCoordinates(); // Fetch sellers now that mapRef is ready
+            }
           }}
+          ref={mapRef}
           className="w-full flex-1 fixed bottom-0 h-[calc(100vh-76.19px)] left-0 right-0"
         >
           <TileLayer

--- a/src/components/shared/map/Map.tsx
+++ b/src/components/shared/map/Map.tsx
@@ -157,7 +157,7 @@ const Map = ({
   // Function to fetch initial coordinates
   const fetchInitialCoordinates = async () => {
     if (searchQuery) return;
-  
+    
     setLoading(true);
     setError(null);
   
@@ -166,11 +166,14 @@ const Map = ({
   
       if (!mapInstance) {
         logger.warn('Map instance is not ready yet');
-        return; // Exit early if the map is not ready
+        return;
       }
   
-      // Fetch the current map bounds
+      logger.info('Map instance:', mapInstance);
+  
+      // Fetch the bounds using mapInstance.target.getBounds()
       const bounds = mapInstance.getBounds();
+      logger.info('Fetched map bounds:', bounds); // Debug log for bounds
   
       if (bounds) {
         let sellersData = await fetchSellerCoordinates(bounds, '');
@@ -183,8 +186,7 @@ const Map = ({
     } finally {
       setLoading(false);
     }
-  };
-  
+  };  
 
   // Function to handle map interactions (only when there's no search query)
   const handleMapInteraction = async (newBounds: L.LatLngBounds, mapInstance: L.Map) => {
@@ -337,8 +339,9 @@ const Map = ({
           zoomControl={false}
           minZoom={2}
           maxZoom={18}
-          whenReady={(mapInstance) => {
-            mapRef.current = mapInstance.target; // Set mapRef correctly
+          whenReady={(mapInstance: any) => {
+            mapRef.current = mapInstance.target; // Use mapInstance.target as the actual map object
+            fetchInitialCoordinates();        // Fetch sellers now that mapRef is ready
           }}
           className="w-full flex-1 fixed bottom-0 h-[calc(100vh-76.19px)] left-0 right-0"
         >

--- a/src/components/shared/map/Map.tsx
+++ b/src/components/shared/map/Map.tsx
@@ -339,9 +339,11 @@ const Map = ({
           zoomControl={false}
           minZoom={2}
           maxZoom={18}
-          whenReady={(mapInstance) => {
-            mapRef.current = mapInstance;        // Fetch sellers now that mapRef is ready
-          }}
+          whenReady={
+            ((mapInstance: L.Map) => {
+              mapRef.current = mapInstance;
+            }) as unknown as () => void // utilize Type assertion
+          }
           className="w-full flex-1 fixed bottom-0 h-[calc(100vh-76.19px)] left-0 right-0"
         >
           <TileLayer


### PR DESCRIPTION
In this PR, we fixed the issue where map markers didn't display until the user moved the map.

We removed the initial useEffect that called fetchInitialCoordinates prematurely and instead used the whenReady prop on MapContainer to set mapRef.current and fetch sellers only after the map is initialized. This ensures that mapRef.current is available before attempting to fetch sellers, allowing markers to load correctly on the initial map load.