### PR TITLE
Feature/local translation persistence

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -240,5 +240,9 @@
       "SUBMISSION_FAILED_USER_NOT_AUTHENTICATED": "فشل الإرسال لأن المستخدم غير مصدق",
       "UNEXPECTED_ERROR_MESSAGE": "حدث خطأ غير متوقع"
     }
+  },
+  "ERROR": {
+    "PAGE_NOT_FOUND_HEADER": "الصفحة غير موجودة",
+    "PAGE_NOT_FOUND_MESSAGE": "عذرًا، الصفحة التي تبحث عنها غير موجودة."
   }
 }

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -231,8 +231,7 @@
     "MAP_CENTER": {
       "SEARCH_BAR_PLACEHOLDER": "ابحث عن موقع، مدينة، أو عنوان",
       "VALIDATION": {
-        "SEARCH_CENTER_SUCCESS_MESSAGE": "تم حفظ مركز البحث بنجاح",
-        "SELL_CENTER_SUCCESS_MESSAGE": "تم حفظ مركز البيع بنجاح"
+        "CENTER_SUCCESS_MESSAGE": "تم حفظ مركزك بنجاح"
       }
     },
     "LOADING_SCREEN_MESSAGE": "جار التحميل ...",

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -231,7 +231,7 @@
     "MAP_CENTER": {
       "SEARCH_BAR_PLACEHOLDER": "ابحث عن موقع، مدينة، أو عنوان",
       "VALIDATION": {
-        "CENTER_SUCCESS_MESSAGE": "تم حفظ مركزك بنجاح"
+        "MAP_CENTER_SUCCESS_MESSAGE": "تم حفظ مركزك بنجاح"
       }
     },
     "LOADING_SCREEN_MESSAGE": "جار التحميل ...",

--- a/messages/en-GB.json
+++ b/messages/en-GB.json
@@ -243,7 +243,7 @@
     "MAP_CENTER": {
       "SEARCH_BAR_PLACEHOLDER": "Search a location, city, or address",
       "VALIDATION": {
-        "SEARCH_CENTER_SUCCESS_MESSAGE": "Your Search Centre has been saved successfully"
+        "CENTER_SUCCESS_MESSAGE": "Your centre has been saved successfully"
       }
     },
     "LOADING_SCREEN_MESSAGE": "Loading ...",

--- a/messages/en-GB.json
+++ b/messages/en-GB.json
@@ -252,5 +252,9 @@
       "SUBMISSION_FAILED_USER_NOT_AUTHENTICATED": "Submission failed because user is not authenticated",
       "UNEXPECTED_ERROR_MESSAGE": "Unexpected error occurred"  
     }
+  },
+  "ERROR": {
+    "PAGE_NOT_FOUND_HEADER": "Page not found",
+    "PAGE_NOT_FOUND_MESSAGE": "Sorry, the page you are looking for does not exist."
   }
 }

--- a/messages/en-GB.json
+++ b/messages/en-GB.json
@@ -243,7 +243,7 @@
     "MAP_CENTER": {
       "SEARCH_BAR_PLACEHOLDER": "Search a location, city, or address",
       "VALIDATION": {
-        "CENTER_SUCCESS_MESSAGE": "Your centre has been saved successfully"
+        "MAP_CENTER_SUCCESS_MESSAGE": "Your centre has been saved successfully"
       }
     },
     "LOADING_SCREEN_MESSAGE": "Loading ...",

--- a/messages/en.json
+++ b/messages/en.json
@@ -231,8 +231,7 @@
     "MAP_CENTER": {
       "SEARCH_BAR_PLACEHOLDER": "Search a location, city, or address",
       "VALIDATION": {
-        "SEARCH_CENTER_SUCCESS_MESSAGE": "Your Search Center has been saved successfully",
-        "SELL_CENTER_SUCCESS_MESSAGE": "Your Sell Center has been saved successfully"
+        "CENTER_SUCCESS_MESSAGE": "Your center has been saved successfully"
       }
     },
     "LOADING_SCREEN_MESSAGE": "Loading ...",

--- a/messages/en.json
+++ b/messages/en.json
@@ -231,7 +231,7 @@
     "MAP_CENTER": {
       "SEARCH_BAR_PLACEHOLDER": "Search a location, city, or address",
       "VALIDATION": {
-        "CENTER_SUCCESS_MESSAGE": "Your center has been saved successfully"
+        "MAP_CENTER_SUCCESS_MESSAGE": "Your center has been saved successfully"
       }
     },
     "LOADING_SCREEN_MESSAGE": "Loading ...",

--- a/messages/en.json
+++ b/messages/en.json
@@ -240,5 +240,9 @@
       "SUBMISSION_FAILED_USER_NOT_AUTHENTICATED": "Submission failed because user is not authenticated",
       "UNEXPECTED_ERROR_MESSAGE": "Unexpected error occurred"
     }
+  },
+  "ERROR": {
+    "PAGE_NOT_FOUND_HEADER": "Page not found",
+    "PAGE_NOT_FOUND_MESSAGE": "Sorry, the page you are looking for does not exist."
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -230,7 +230,7 @@
     "MAP_CENTER": {
       "SEARCH_BAR_PLACEHOLDER": "Buscar una ubicación, ciudad o dirección",
       "VALIDATION": {
-        "SEARCH_CENTER_SUCCESS_MESSAGE": "Tu centro de búsqueda se ha guardado correctamente"
+        "CENTER_SUCCESS_MESSAGE": "Su centro ha sido guardado con éxito"
       }
     },
     "LOADING_SCREEN_MESSAGE": "Cargando ...",

--- a/messages/es.json
+++ b/messages/es.json
@@ -239,5 +239,9 @@
       "SUBMISSION_FAILED_USER_NOT_AUTHENTICATED": "El envío falló porque el usuario no está autenticado",
       "UNEXPECTED_ERROR_MESSAGE": "Ocurrió un error inesperado"
     }
+  },
+  "ERROR": {
+    "PAGE_NOT_FOUND_HEADER": "Página no encontrada",
+    "PAGE_NOT_FOUND_MESSAGE": "Lo sentimos, la página que buscas no existe."
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -230,7 +230,7 @@
     "MAP_CENTER": {
       "SEARCH_BAR_PLACEHOLDER": "Buscar una ubicación, ciudad o dirección",
       "VALIDATION": {
-        "CENTER_SUCCESS_MESSAGE": "Su centro ha sido guardado con éxito"
+        "MAP_CENTER_SUCCESS_MESSAGE": "Su centro ha sido guardado con éxito"
       }
     },
     "LOADING_SCREEN_MESSAGE": "Cargando ...",

--- a/messages/ewe-BJ.json
+++ b/messages/ewe-BJ.json
@@ -230,7 +230,7 @@
     "MAP_CENTER": {
       "SEARCH_BAR_PLACEHOLDER": "Nemo wuri, gari ko adireshi",
       "VALIDATION": {
-        "SEARCH_CENTER_SUCCESS_MESSAGE": "Nye dzi tsɔtɔ wɔm o"
+        "CENTER_SUCCESS_MESSAGE": "Woƒe xɔ sia le afisi mɔ na mi"
       }
     },
     "LOADING_SCREEN_MESSAGE": "Gɔme ɖa ...",

--- a/messages/ewe-BJ.json
+++ b/messages/ewe-BJ.json
@@ -239,5 +239,9 @@
       "SUBMISSION_FAILED_USER_NOT_AUTHENTICATED": "Nɔvia míaɖu abe nu wò ye mele wònu o le fifiawo nyo",
       "UNEXPECTED_ERROR_MESSAGE": "Nuxlɔ̃sia na mi ɖe mɔ o"
     }
+  },
+  "ERROR": {
+    "PAGE_NOT_FOUND_HEADER": "Fia na wòhù",
+    "PAGE_NOT_FOUND_MESSAGE": "Mègbè, pàg nà wòhù nà àtsia nè."
   }
 }

--- a/messages/ewe-BJ.json
+++ b/messages/ewe-BJ.json
@@ -230,7 +230,7 @@
     "MAP_CENTER": {
       "SEARCH_BAR_PLACEHOLDER": "Nemo wuri, gari ko adireshi",
       "VALIDATION": {
-        "CENTER_SUCCESS_MESSAGE": "Woƒe xɔ sia le afisi mɔ na mi"
+        "MAP_CENTER_SUCCESS_MESSAGE": "Woƒe xɔ sia le afisi mɔ na mi"
       }
     },
     "LOADING_SCREEN_MESSAGE": "Gɔme ɖa ...",

--- a/messages/hau-NG.json
+++ b/messages/hau-NG.json
@@ -228,6 +228,7 @@
       }
     },
     "MAP_CENTER": {
+      "SEARCH_BAR_PLACEHOLDER": "Nema wuri, birni, ko adireshi",
       "VALIDATION": {
         "CENTER_SUCCESS_MESSAGE": "An adana cibiyar ku cikin nasara"
       }

--- a/messages/hau-NG.json
+++ b/messages/hau-NG.json
@@ -229,7 +229,7 @@
     },
     "MAP_CENTER": {
       "VALIDATION": {
-        "SEARCH_CENTER_SUCCESS_MESSAGE": "An adana Cibiyar Bincike ɗinku cikin nasara"
+        "CENTER_SUCCESS_MESSAGE": "An adana cibiyar ku cikin nasara"
       }
     },
     "LOADING_SCREEN_MESSAGE": "Ana loda ...",

--- a/messages/hau-NG.json
+++ b/messages/hau-NG.json
@@ -230,7 +230,7 @@
     "MAP_CENTER": {
       "SEARCH_BAR_PLACEHOLDER": "Nema wuri, birni, ko adireshi",
       "VALIDATION": {
-        "CENTER_SUCCESS_MESSAGE": "An adana cibiyar ku cikin nasara"
+        "MAP_CENTER_SUCCESS_MESSAGE": "An adana cibiyar ku cikin nasara"
       }
     },
     "LOADING_SCREEN_MESSAGE": "Ana loda ...",

--- a/messages/hau-NG.json
+++ b/messages/hau-NG.json
@@ -239,5 +239,9 @@
       "SUBMISSION_FAILED_USER_NOT_AUTHENTICATED": "Aika ya kasa saboda mai amfani ba a tabbatar da shi ba",
       "UNEXPECTED_ERROR_MESSAGE": "An samu kuskure da ba a zata ba"
     }
+  },
+  "ERROR": {
+    "PAGE_NOT_FOUND_HEADER": "Shafin ba a samu ba",
+    "PAGE_NOT_FOUND_MESSAGE": "Yi hakuri, shafin da kake nema ba ya wanzu."
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -230,7 +230,7 @@
     "MAP_CENTER": {
       "SEARCH_BAR_PLACEHOLDER": "위치, 도시 또는 주소 검색",
       "VALIDATION": {
-        "CENTER_SUCCESS_MESSAGE": "귀하의 센터가 성공적으로 저장되었습니다"
+        "MAP_CENTER_SUCCESS_MESSAGE": "귀하의 센터가 성공적으로 저장되었습니다"
       }
     },
     "LOADING_SCREEN_MESSAGE": "로딩 중 ...",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -230,7 +230,7 @@
     "MAP_CENTER": {
       "SEARCH_BAR_PLACEHOLDER": "위치, 도시 또는 주소 검색",
       "VALIDATION": {
-        "SEARCH_CENTER_SUCCESS_MESSAGE": "검색 센터가 성공적으로 저장되었습니다"
+        "CENTER_SUCCESS_MESSAGE": "귀하의 센터가 성공적으로 저장되었습니다"
       }
     },
     "LOADING_SCREEN_MESSAGE": "로딩 중 ...",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -239,5 +239,9 @@
       "SUBMISSION_FAILED_USER_NOT_AUTHENTICATED": "제출이 실패했습니다; 사용자가 인증되지 않았습니다",
       "UNEXPECTED_ERROR_MESSAGE": "예기치 않은 오류가 발생했습니다"
     }
+  },
+  "ERROR": {
+    "PAGE_NOT_FOUND_HEADER": "페이지를 찾을 수 없습니다",
+    "PAGE_NOT_FOUND_MESSAGE": "죄송합니다, 찾고 있는 페이지는 존재하지 않습니다."
   }
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -4,8 +4,9 @@ import { Lato } from 'next/font/google';
 import { Providers } from '../providers';
 
 import Navbar from '@/components/shared/navbar/Navbar';
-
 import logger from '../../../logger.config.mjs';
+
+export const dynamic = 'force-dynamic';
 
 const lato = Lato({ weight: '400', subsets: ['latin'], display: 'swap' });
 

--- a/src/app/[locale]/map-center/page.tsx
+++ b/src/app/[locale]/map-center/page.tsx
@@ -1,21 +1,20 @@
-'use client';
-
 import dynamic from 'next/dynamic';
-import { useSearchParams } from 'next/navigation';
 
-const MapCenterPage = () => {
-  const searchParams = useSearchParams();
-  const entryType = searchParams.get('entryType'); // Get 'entryType' from URL query params
+interface MapCenterPageProps {
+  searchParams: { entryType?: string };
+  params: { locale: string };
+}
 
+const MapCenterPage = ({ searchParams, params}: MapCenterPageProps) => {
+  const { entryType = 'search' } = searchParams;
+  const { locale } = params;
   // Dynamically import the MapCenter component
   const MapCenter = dynamic(() => import('@/components/shared/map/MapCenter'), {
     ssr: false,
   });
 
   return (
-    <>
-      <MapCenter entryType={entryType as 'search' | 'sell'} /> {/* Pass entryType as a prop */}
-    </>
+    <MapCenter entryType={entryType as 'search' | 'sell'} locale={locale} /> /* Pass entryType as a prop with locale */
   );
 };
 

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -18,8 +18,7 @@ import { userLocation } from '@/utils/geolocation';
 import { AppContext } from '../../../context/AppContextProvider';
 import logger from '../../../logger.config.mjs';
 
-export default function Page({ params }: { params: {locale: string } }) {
-  const locale = params;
+export default function Page({ params }: { params: { locale: string } }) {
   const t = useTranslations();
   const DynamicMap = dynamic(() => import('@/components/shared/map/Map'), {
     ssr: false,
@@ -137,7 +136,7 @@ export default function Page({ params }: { params: {locale: string } }) {
         <div className="w-[90%] lg:w-full lg:px-6 mx-auto flex items-center justify-between">
           {/* Add Seller Button */}
           <div className="pointer-events-auto">
-            <Link href={`/seller/registration`}>
+            <Link href={'/seller/registration'}>
               <Button
                 label={'+ ' + t('HOME.ADD_SELLER')}
                 styles={{

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -18,7 +18,8 @@ import { userLocation } from '@/utils/geolocation';
 import { AppContext } from '../../../context/AppContextProvider';
 import logger from '../../../logger.config.mjs';
 
-export default function Index() {
+export default function page({ params }: { params: {locale: string } }) {
+  const locale = params;
   const t = useTranslations();
   const DynamicMap = dynamic(() => import('@/components/shared/map/Map'), {
     ssr: false,
@@ -128,7 +129,7 @@ export default function Index() {
         <div className="w-[90%] lg:w-full lg:px-6 mx-auto flex items-center justify-between">
           {/* Add Seller Button */}
           <div className="pointer-events-auto">
-            <Link href="/seller/registration">
+            <Link href={`/${locale}/seller/registration`}>
               <Button
                 label={'+ ' + t('HOME.ADD_SELLER')}
                 styles={{

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -18,7 +18,7 @@ import { userLocation } from '@/utils/geolocation';
 import { AppContext } from '../../../context/AppContextProvider';
 import logger from '../../../logger.config.mjs';
 
-export default function page({ params }: { params: {locale: string } }) {
+export default function Page({ params }: { params: {locale: string } }) {
   const locale = params;
   const t = useTranslations();
   const DynamicMap = dynamic(() => import('@/components/shared/map/Map'), {
@@ -129,7 +129,7 @@ export default function page({ params }: { params: {locale: string } }) {
         <div className="w-[90%] lg:w-full lg:px-6 mx-auto flex items-center justify-between">
           {/* Add Seller Button */}
           <div className="pointer-events-auto">
-            <Link href={`/${locale}/seller/registration`}>
+            <Link href={`/seller/registration`}>
               <Button
                 label={'+ ' + t('HOME.ADD_SELLER')}
                 styles={{

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -20,6 +20,7 @@ import logger from '../../../logger.config.mjs';
 
 export default function Page({ params }: { params: { locale: string } }) {
   const t = useTranslations();
+  const { locale } = params;
   const DynamicMap = dynamic(() => import('@/components/shared/map/Map'), {
     ssr: false,
   });
@@ -136,7 +137,7 @@ export default function Page({ params }: { params: { locale: string } }) {
         <div className="w-[90%] lg:w-full lg:px-6 mx-auto flex items-center justify-between">
           {/* Add Seller Button */}
           <div className="pointer-events-auto">
-            <Link href={'/seller/registration'}>
+            <Link href={`/${locale}/seller/registration`}>
               <Button
                 label={'+ ' + t('HOME.ADD_SELLER')}
                 styles={{

--- a/src/app/[locale]/seller/registration/page.tsx
+++ b/src/app/[locale]/seller/registration/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useTranslations } from 'next-intl';
+import { useTranslations, useLocale } from 'next-intl';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState, useEffect, useContext } from 'react';
@@ -30,6 +30,7 @@ const SellerRegistrationForm = () => {
   const HEADER = 'font-bold text-lg md:text-2xl';
   const SUBHEADER = 'font-bold mb-2';
   const router = useRouter();
+  const locale = useLocale();
   const t = useTranslations();
   const placeholderSeller = itemData.seller;
 
@@ -373,7 +374,7 @@ const SellerRegistrationForm = () => {
         </div>
         <Link
           href={{
-            pathname: '/map-center', // Path to MapCenter component
+          pathname: `/${locale}/map-center`, // Path to MapCenter component
             query: { entryType: 'sell' }, // Passing 'sell' as entryType
           }}>
           <Button
@@ -470,7 +471,7 @@ const SellerRegistrationForm = () => {
                 <Link
                   href={
                     dbSeller
-                      ? `/seller/reviews/${dbSeller.seller_id}?user_name=${currentUser?.pi_username}`
+                      ? `/${locale}/seller/reviews/${dbSeller.seller_id}?user_name=${currentUser?.pi_username}`
                       : '#'
                   }>
                   <OutlineBtn
@@ -485,7 +486,7 @@ const SellerRegistrationForm = () => {
                   onClick={() =>
                     handleNavigation(
                       dbSeller
-                        ? `/seller/reviews/${dbSeller.seller_id}?user_name=${currentUser?.pi_username}`
+                        ? `/${locale}/seller/reviews/${dbSeller.seller_id}?user_name=${currentUser?.pi_username}`
                         : '#',
                     )
                   }

--- a/src/app/[locale]/seller/reviews/[id]/page.tsx
+++ b/src/app/[locale]/seller/reviews/[id]/page.tsx
@@ -296,7 +296,7 @@ function SellerReviews({
                     </p>
                   </div>
                   <div className="flex justify-between items-center">
-                    <Link href={`/${locale}seller/reviews/feedback/${review.reviewId}?seller_name=${review.giver}`}>
+                    <Link href={`/${locale}/seller/reviews/feedback/${review.reviewId}?seller_name=${review.giver}`}>
                       <OutlineBtn label={t('SHARED.REPLY')} />
                     </Link>
                   </div>

--- a/src/app/[locale]/seller/reviews/[id]/page.tsx
+++ b/src/app/[locale]/seller/reviews/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useTranslations } from 'next-intl';
+import { useTranslations, useLocale } from 'next-intl';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useState, useRef, useContext } from 'react';
@@ -29,6 +29,7 @@ function SellerReviews({
   const t = useTranslations();
   const userName = useRef<string>(searchParams.user_name);
   const userId = params.id;
+  const locale = useLocale;
 
   const [giverReviews, setGiverReviews] = useState<ReviewInt[] | null>(null);
   const [receiverReviews, setReceiverReviews] = useState<ReviewInt[] | null>(null);
@@ -251,7 +252,7 @@ function SellerReviews({
                       </p>
                     </div>
                     <div className="flex justify-between items-center">
-                      <Link href={`/seller/reviews/feedback/${review.reviewId}?user_name=${review.giver}`}>
+                      <Link href={`/${locale}/seller/reviews/feedback/${review.reviewId}?user_name=${review.giver}`}>
                         <OutlineBtn label={t('SHARED.REPLY')} />
                       </Link>
                     </div>
@@ -306,7 +307,7 @@ function SellerReviews({
                     </p>
                   </div>
                   <div className="flex justify-between items-center">
-                    <Link href={`/seller/reviews/feedback/${review.reviewId}?seller_name=${review.giver}`}>
+                    <Link href={`/${locale}seller/reviews/feedback/${review.reviewId}?seller_name=${review.giver}`}>
                       <OutlineBtn label={t('SHARED.REPLY')} />
                     </Link>
                   </div>

--- a/src/app/[locale]/seller/reviews/feedback/[id]/page.tsx
+++ b/src/app/[locale]/seller/reviews/feedback/[id]/page.tsx
@@ -185,7 +185,7 @@ export default function ReplyToReviewPage({ params }: ReplyToReviewPageProps) {
 
           <h2 className="font-bold">{t('SCREEN.REPLY_TO_REVIEW.GIVE_REPLY_TO_REVIEW_SUBHEADER')}</h2>
           <h2 className="text-[#828282]">
-            {t('To')}: {currentUser?.user_name === reviews[currentIndex].giver
+            {t('SCREEN.REPLY_TO_REVIEW.TO')}: {currentUser?.user_name === reviews[currentIndex].giver
               ? reviews[currentIndex]?.receiver
               : reviews[currentIndex].giver}
           </h2>

--- a/src/app/[locale]/seller/sale-items/[id]/page.tsx
+++ b/src/app/[locale]/seller/sale-items/[id]/page.tsx
@@ -153,7 +153,7 @@ export default function BuyFromSellerForm({ params }: { params: { id: string } }
             <p className="text-sm">
               {t('SCREEN.BUY_FROM_SELLER.REVIEWS_SCORE_MESSAGE', {seller_review_rating: sellerShopInfo.average_rating.$numberDecimal})}
             </p>
-            <Link href={`/${locale}seller/reviews/${sellerId}?buyer=true&user_name=${sellerInfo?.pi_username}`}>
+            <Link href={`/${locale}/seller/reviews/${sellerId}?buyer=true&user_name=${sellerInfo?.pi_username}`}>
             <OutlineBtn label={t('SHARED.CHECK_REVIEWS')} />
             </Link>
           </div>

--- a/src/app/[locale]/seller/sale-items/[id]/page.tsx
+++ b/src/app/[locale]/seller/sale-items/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useTranslations } from 'next-intl';
+import { useTranslations, useLocale } from 'next-intl';
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -21,9 +21,8 @@ import logger from '../../../../../../logger.config.mjs';
 
 export default function BuyFromSellerForm({ params }: { params: { id: string } }) {
   const SUBHEADER = "font-bold mb-2";
-
   const t = useTranslations();
-
+  const locale = useLocale();
   const sellerId = params.id; 
 
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
@@ -154,7 +153,7 @@ export default function BuyFromSellerForm({ params }: { params: { id: string } }
             <p className="text-sm">
               {t('SCREEN.BUY_FROM_SELLER.REVIEWS_SCORE_MESSAGE', {seller_review_rating: sellerShopInfo.average_rating.$numberDecimal})}
             </p>
-            <Link href={`/seller/reviews/${sellerId}?buyer=true&user_name=${sellerInfo?.pi_username}`}>
+            <Link href={`/${locale}seller/reviews/${sellerId}?buyer=true&user_name=${sellerInfo?.pi_username}`}>
             <OutlineBtn label={t('SHARED.CHECK_REVIEWS')} />
             </Link>
           </div>

--- a/src/app/_not-found/page.tsx
+++ b/src/app/_not-found/page.tsx
@@ -1,0 +1,11 @@
+// app/_not-found/page.tsx
+export const dynamic = 'force-dynamic';
+
+export default function NotFound() {
+  return (
+    <div>
+      <h1>404 - Page Not Found</h1>
+      <p>Sorry, the page you are looking for does not exist.</p>
+    </div>
+  );
+}

--- a/src/app/_not-found/page.tsx
+++ b/src/app/_not-found/page.tsx
@@ -1,10 +1,9 @@
-// app/_not-found/page.tsx
 export const dynamic = 'force-dynamic';
 
 export default function NotFound() {
   return (
     <div>
-      <h1>404 - Page Not Found</h1>
+      <h1>404 | Page Not Found</h1>
       <p>Sorry, the page you are looking for does not exist.</p>
     </div>
   );

--- a/src/app/_not-found/page.tsx
+++ b/src/app/_not-found/page.tsx
@@ -1,10 +1,16 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
 export const dynamic = 'force-dynamic';
 
 export default function NotFound() {
+  const t = useTranslations();
+
   return (
     <div>
-      <h1>404 | Page Not Found</h1>
-      <p>Sorry, the page you are looking for does not exist.</p>
+      <h1>404 | {t('ERROR.PAGE_NOT_FOUND_HEADER')}</h1>
+      <p>{t('ERROR.PAGE_NOT_FOUND_MESSAGE')}</p>
     </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,30 @@
-"use client"
-
 import './global.css';
 import { ReactNode } from 'react';
+import { NextIntlClientProvider } from 'next-intl';
 import '../../sentry.client.config.mjs';
 
 type Props = {
   children: ReactNode;
+  params?: { locale?: string };
 };
 
-export default function RootLayout({ children }: Props) {
-  return children;
+export default async function RootLayout({ children, params = { locale: 'en' } }: Props) {
+  const locale = params.locale || 'en';
+
+  let messages;
+  try {
+    messages = (await import(`../../messages/${locale}.json`)).default;
+  } catch (error) {
+    messages = (await import(`../../messages/en.json`)).default;
+  }
+
+  return (
+    <html lang={locale}>
+      <body>
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          {children}
+        </NextIntlClientProvider>
+      </body>
+    </html>
+  );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { ReactNode } from 'react';
 import { NextIntlClientProvider } from 'next-intl';
 import '../../sentry.client.config.mjs';
 
+export const dynamic = 'force-dynamic';
+
 type Props = {
   children: ReactNode;
   params?: { locale?: string };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,7 @@
 import { redirect } from 'next/navigation';
 
+export const dynamic = 'force-dynamic';
+
 // This page only renders when the app is built statically (output: 'export')
 export default function RootPage() {
   redirect('/en');

--- a/src/components/shared/map/MapCenter.tsx
+++ b/src/components/shared/map/MapCenter.tsx
@@ -34,6 +34,7 @@ const crosshairIcon = new L.Icon({
 
 interface MapCenterProps {
   entryType: 'search' | 'sell';
+  locale: string;
 }
 
 const MapCenter = ({ entryType }: MapCenterProps) => {

--- a/src/components/shared/map/MapCenter.tsx
+++ b/src/components/shared/map/MapCenter.tsx
@@ -238,7 +238,7 @@ const MapCenter = ({ entryType }: MapCenterProps) => {
         <ConfirmDialogX
           toggle={() => setShowPopup(false)}
           handleClicked={handleClickDialog}
-          message={t('SHARED.MAP_CENTER.VALIDATION.CENTER_SUCCESS_MESSAGE')}
+          message={t('SHARED.MAP_CENTER.VALIDATION.MAP_CENTER_SUCCESS_MESSAGE')}
         />
       )}
     </div>

--- a/src/components/shared/map/MapCenter.tsx
+++ b/src/components/shared/map/MapCenter.tsx
@@ -238,12 +238,7 @@ const MapCenter = ({ entryType }: MapCenterProps) => {
         <ConfirmDialogX
           toggle={() => setShowPopup(false)}
           handleClicked={handleClickDialog}
-          // Dynamically set the message based on entryType
-          message={
-            entryType === 'sell'
-              ? t('SHARED.MAP_CENTER.VALIDATION.SELL_CENTER_SUCCESS_MESSAGE')
-              : t('SHARED.MAP_CENTER.VALIDATION.SEARCH_CENTER_SUCCESS_MESSAGE')
-          }
+          message={t('SHARED.MAP_CENTER.VALIDATION.CENTER_SUCCESS_MESSAGE')}
         />
       )}
     </div>

--- a/src/components/shared/map/MapMarkerPopup.tsx
+++ b/src/components/shared/map/MapMarkerPopup.tsx
@@ -1,4 +1,4 @@
-import { useTranslations } from 'next-intl';
+import { useTranslations, useLocale } from 'next-intl';
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -9,6 +9,7 @@ import logger from '../../../../logger.config.mjs';
 
 const MapMarkerPopup = ({ seller }: { seller: any }) => {
   const t = useTranslations();
+  const locale = useLocale();
 
   const imageUrl =
     seller.image && seller.image.trim() !== ''
@@ -70,7 +71,7 @@ const MapMarkerPopup = ({ seller }: { seller: any }) => {
       {/* Link to Buy button */}
       <div style={{ display: 'flex', justifyContent: 'center', marginTop: '5px' }}>
         <Link
-          href={`/seller/sale-items/${seller.seller_id}`} // Update to your target link
+          href={`/${locale}/seller/sale-items/${seller.seller_id}`} // Update to your target link
           style={{ display: 'flex', justifyContent: 'center', width: '100%' }}
         >
           <Button

--- a/src/components/shared/sidebar/sidebar.tsx
+++ b/src/components/shared/sidebar/sidebar.tsx
@@ -53,7 +53,7 @@ function isLanguageMenuItem(item: MenuItem): item is LanguageMenuItem {
 function Sidebar(props: any) {
   const t = useTranslations();
   const pathname = usePathname();
-  const local = useLocale();
+  const locale = useLocale();
   const router = useRouter();
 
   const { currentUser, autoLoginUser, setReload, showAlert } = useContext(AppContext);
@@ -250,7 +250,7 @@ function Sidebar(props: any) {
         setIsSaveEnabled(false);
         logger.info('User Settings saved successfully:', { data });
         showAlert(t('SIDE_NAVIGATION.VALIDATION.SUCCESSFUL_PREFERENCES_SUBMISSION'));
-        if (pathname === '/' || pathname === `/${local}`) {
+        if (pathname === '/' || pathname === `/${locale}`) {
           setReload(true);
         }
       }
@@ -335,7 +335,7 @@ function Sidebar(props: any) {
                   fontSize: '18px' 
                 }}
                 onClick={() => {
-                  router.push(`/map-center?entryType=search`);
+                  router.push(`/${locale}/map-center?entryType=search`);
                   props.setToggleDis(false); // Close sidebar on click
                 }}
               />
@@ -374,7 +374,7 @@ function Sidebar(props: any) {
               <h3 className={`font-bold text-sm text-nowrap`}>Trust-o-meter</h3>
               <TrustMeter ratings={dbUserSettings ? dbUserSettings.trust_meter_rating : 100} hideLabel={true} />
             </div>             
-            <Link href={currentUser ? `/seller/reviews/${currentUser?.pi_uid}?user_name=${currentUser.user_name}` : '#'}>
+            <Link href={currentUser ? `/${locale}/seller/reviews/${currentUser?.pi_uid}?user_name=${currentUser.user_name}` : '#'}>
               <OutlineBtn
                 label={t('SHARED.CHECK_REVIEWS')}
                 styles={{
@@ -510,6 +510,7 @@ function Sidebar(props: any) {
       {/* Conditionally render MapCenter */}
       {showMapCenter && (
         <MapCenter
+          locale={locale}
           entryType="search"
         />
       )}

--- a/src/components/skeleton/skeleton.tsx
+++ b/src/components/skeleton/skeleton.tsx
@@ -7,7 +7,10 @@ import { SkeletonSidebar } from './Sidebar';
 
 function Skeleton(props : any) {
     if (props.type === "seller_registration") return <SkeletonSellerRegistration />;
-    if (props.type === "seller_review") return Array(8).fill(<SkeletonSellerReview />);
+    if (props.type === "seller_review") 
+        return Array(8).fill(null).map((_, index) => (
+            <SkeletonSellerReview key={index} />
+        ));
     if (props.type === "seller_item") return <SkeletonSellerItem />;
     if (props.type === "sidebar") return <SkeletonSidebar />;
 }

--- a/src/components/skeleton/skeleton.tsx
+++ b/src/components/skeleton/skeleton.tsx
@@ -7,10 +7,11 @@ import { SkeletonSidebar } from './Sidebar';
 
 function Skeleton(props : any) {
     if (props.type === "seller_registration") return <SkeletonSellerRegistration />;
-    if (props.type === "seller_review") 
-        return Array(8).fill(null).map((_, index) => (
-            <SkeletonSellerReview key={index} />
-        ));
+    if (props.type === "seller_review") {
+      return Array(8).fill(null).map((_, index) => (
+          <SkeletonSellerReview key={index} />
+      ));
+    }
     if (props.type === "seller_item") return <SkeletonSellerItem />;
     if (props.type === "sidebar") return <SkeletonSidebar />;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import createMiddleware from 'next-intl/middleware';
 import { localePrefix } from './navigation';
 
-// We are not using localePrefix here to maintain more direct control over
+// We are not using localePrefix directly here to maintain more direct control over
 // locale handling, manually specifying locales in route paths where needed.
 const locales = ['en', 'es', 'ar', 'ko', 'hau-NG', 'ewe-BJ'];
 const defaultLocale = 'en';
@@ -9,7 +9,7 @@ const defaultLocale = 'en';
 export default createMiddleware({
   locales,
   defaultLocale,
-  localePrefix, // Optional: if automatic locale prefixing is desired
+  localePrefix: 'always'
 });
 
 export const config = {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,7 +3,7 @@ import { localePrefix } from './navigation';
 
 // We are not using localePrefix directly here to maintain more direct control over
 // locale handling, manually specifying locales in route paths where needed.
-const locales = ['en', 'es', 'ar', 'ko', 'hau-NG', 'ewe-BJ'];
+const locales = ['en', 'es', 'ar', 'ko', 'en-GB', 'hau-NG', 'ewe-BJ'];
 const defaultLocale = 'en';
 
 export default createMiddleware({

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,8 @@
 import createMiddleware from 'next-intl/middleware';
-import { localePrefix } from './navigation';
 
 // We are not using localePrefix directly here to maintain more direct control over
 // locale handling, manually specifying locales in route paths where needed.
-const locales = ['en', 'es', 'ar', 'ko', 'en-GB', 'hau-NG', 'ewe-BJ'];
+const locales = ['ar', 'en', 'en-GB', 'es', 'ewe-BJ', 'hau-NG', 'ko'];
 const defaultLocale = 'en';
 
 export default createMiddleware({

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,5 @@
 import createMiddleware from 'next-intl/middleware';
+import { localePrefix } from './navigation';
 
 // We are not using localePrefix here to maintain more direct control over
 // locale handling, manually specifying locales in route paths where needed.
@@ -8,7 +9,7 @@ const defaultLocale = 'en';
 export default createMiddleware({
   locales,
   defaultLocale,
-  // localePrefix, // Optional:  Uncomment if automatic locale prefixing is desired
+  localePrefix, // Optional: if automatic locale prefixing is desired
 });
 
 export const config = {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,14 @@
 import createMiddleware from 'next-intl/middleware';
 
-import { locales, localePrefix } from './navigation';
+// We are not using localePrefix here to maintain more direct control over
+// locale handling, manually specifying locales in route paths where needed.
+const locales = ['en', 'es', 'ar', 'ko', 'hau-NG', 'ewe-BJ'];
+const defaultLocale = 'en';
 
 export default createMiddleware({
-  defaultLocale: 'en',
-  localePrefix,
   locales,
+  defaultLocale,
+  // localePrefix, // Optional:  Uncomment if automatic locale prefixing is desired
 });
 
 export const config = {


### PR DESCRIPTION
### Summary

This PR focuses on stabilizing the translation system across the app, ensuring a seamless experience when switching languages and navigating between screens. We've set up most translation elements to work consistently within the app session, which is the groundwork for keeping the chosen language active even on reloads or across sessions.

**What’s been done:**

- Refactored Middleware: Made changes to allow for more manual control over locale settings, which helps with handling locale consistency across different app areas.

- Updated Layouts: Added localization support to RootLayout and other layout components for smoother navigation.

- Enhanced Links: Added the locale parameter to various links, including home, Seller Registration, and Seller Reviews screens, ensuring the chosen language carries over on each page.

- Unified Success Messages: Combined "Sell" and "Search" center success messages into one message for simplicity.

- Added Key Fixes: Addressed the React key warnings in Skeleton components by adding unique keys.

- Uncommented localePrefix: Ensured localePrefix is enabled to better handle errors and stabilize navigation.

- Completed Language Additions: Included en-GB, hau-NG, and other language placeholders where they were missing.

**### Why It Matters:**

This is the first step in making our translation system fully consistent. With these local app-session updates, users can navigate and change languages without seeing inconsistencies or errors. The next step will be to persist these translations even after reloading the app.