### PR TITLE
Attempted fix to resolve phone number cursor issue.

### DIFF
--- a/src/app/[locale]/seller/registration/page.tsx
+++ b/src/app/[locale]/seller/registration/page.tsx
@@ -523,6 +523,7 @@ const SellerRegistrationForm = () => {
                 onChange={(value: any) =>
                   handleChange({ name: 'phone_number', value })
                 }
+                smartCaret={false}
               />
             </div>
             <div className="mb-4">

--- a/src/components/shared/Forms/Inputs/Inputs.tsx
+++ b/src/components/shared/Forms/Inputs/Inputs.tsx
@@ -29,7 +29,7 @@ export const Input = (props: any) => {
 
 
 export const TelephoneInput = (props: any) => {
-  const { label, ...input } = props;
+  const { label, smartCaret, ...input } = props;
   return (
     <div className="">
       {props.label && (
@@ -37,6 +37,7 @@ export const TelephoneInput = (props: any) => {
       )}
       <PhoneInput 
         {...input}
+        smartCaret={smartCaret}
         className={`flex mt-1 p-[10px] w-full rounded-xl border-[#BDBDBD] bg-transparent outline-0 focus:border-[#1d724b] border-[2px] mb-4`}
       />
     </div>


### PR DESCRIPTION
Disabled the `smartCaret` property as an initial step to address the cursor positioning issue observed on the Seller Registration screen.  Cursor behavior can vary across devices due to differences in browser and input handling.  By default, smartCaret is enabled to help maintain a _reasonable_ cursor position during user input; however, disabling it may allow the browser’s native behavior to manage cursor placement more predictably.

**[see commits]**