### PR TITLE
Feature/notifications badge popup UI

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -7,4 +7,6 @@ NODE_ENV=development
 NEXT_PUBLIC_API_URL=http://localhost:8001/api/v1
 NEXT_PUBLIC_PI_SDK_URL=https://sdk.minepi.com/pi-sdk.js
 
-NEXT_PUBLIC_SENTRY_DSN="ADD YOUR SENTRY DSN"
+NEXT_PUBLIC_SENTRY_DSN=https://b87a5eef8816cc12571cfb9647211e89@o4507779280732160.ingest.us.sentry.io/4507807931301888
+
+NEXT_PUBLIC_IMAGE_PLACEHOLDER_URL=https://res.cloudinary.com/dcdcqbdsj/image/upload/v1725882032/map-of-pi-logo_llz7ot.png

--- a/.env.development
+++ b/.env.development
@@ -7,6 +7,5 @@ NODE_ENV=development
 NEXT_PUBLIC_API_URL=http://localhost:8001/api/v1
 NEXT_PUBLIC_PI_SDK_URL=https://sdk.minepi.com/pi-sdk.js
 
-NEXT_PUBLIC_SENTRY_DSN=https://b87a5eef8816cc12571cfb9647211e89@o4507779280732160.ingest.us.sentry.io/4507807931301888
-
-NEXT_PUBLIC_IMAGE_PLACEHOLDER_URL=https://res.cloudinary.com/dcdcqbdsj/image/upload/v1725882032/map-of-pi-logo_llz7ot.png
+NEXT_PUBLIC_SENTRY_DSN="ADD YOUR SENTRY DSN"
+NEXT_PUBLIC_IMAGE_PLACEHOLDER_URL="ADD YOUR IMAGE PLACEHOLDER URL"

--- a/context/AppContextProvider.tsx
+++ b/context/AppContextProvider.tsx
@@ -13,7 +13,7 @@ import axiosClient, { setAuthToken } from '@/config/client';
 import { onIncompletePaymentFound } from '@/config/payment';
 import { AuthResult } from '@/constants/pi';
 import { IUser } from '@/constants/types';
-import { getNotificationsCount } from '@/services/notificationApi';
+import { getNotifications } from '@/services/notificationApi';
 
 import logger from '../logger.config.mjs';
 
@@ -77,7 +77,7 @@ const AppContextProvider = ({ children }: AppContextProviderProps) => {
 
   useEffect(() => {
   if (currentUser) {
-    fetchNotificationsCount(); // ⬅️ Run whenever currentUser changes
+    fetchNotificationsCount();
   }
 }, [currentUser]);
 
@@ -90,15 +90,20 @@ const AppContextProvider = ({ children }: AppContextProviderProps) => {
 
  const fetchNotificationsCount = async () => {
   try {
-    const count = await getNotificationsCount();
+    const { count } = await getNotifications({
+      skip: 0,
+      limit: 1,
+      status: 'uncleared'
+    });
     setNotificationsCount(count);
-    console.log("Fetched notification count:", count);
+    setToggleNotification(count > 0);
   } catch (error) {
     logger.error('Failed to fetch notification count:', error);
     setNotificationsCount(0);
     setToggleNotification(false);
   }
 };
+
 
   /* Register User via Pi SDK */
   const registerUser = async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6177,6 +6177,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -8087,9 +8088,10 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -93,7 +93,6 @@ export default function Page({ params }: { params: { locale: string } }) {
       
       try {
         const notifications = await getNotifications({
-          pi_uid: currentUser.pi_uid,
           skip: 0,
           limit: 0,
           status: 'uncleared'

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -100,7 +100,7 @@ export default function Page({ params }: { params: { locale: string } }) {
 
         console.log('Uncleared notifications response:', notifications);
         
-        if (notifications?.length > 0) {
+        if (notifications?.items?.length > 0) {
           setShowNotificationPopup(true);
           sessionStorage.setItem('notificationShown', 'true');
         } else {

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -105,7 +105,7 @@ export default function Page({ params }: { params: { locale: string } }) {
 
         console.log('Uncleared notifications response:', notifications);
         
-        if (notifications?.length > 0) {
+        if (notifications?.items?.length > 0) {
           setShowNotificationPopup(true);
           sessionStorage.setItem('notificationShown', 'true');
         } else {

--- a/src/components/shared/navbar/Navbar.tsx
+++ b/src/components/shared/navbar/Navbar.tsx
@@ -25,7 +25,12 @@ function Navbar() {
   const [sidebarToggle, setSidebarToggle] = useState(false);
   const [isHomePage, setIsHomePage] = useState(true);
 
-  const {isSigningInUser, reload, alertMessage, isSaveLoading} = useContext(AppContext);
+  const {isSigningInUser, reload, alertMessage, isSaveLoading } = useContext(AppContext);
+  const { notificationsCount } = useContext(AppContext);
+
+  useEffect(() => {
+  console.log("Navbar saw notification count:", notificationsCount);
+}, [notificationsCount]);
 
   // check if the current page is the homepage
   useEffect(() => {
@@ -118,14 +123,21 @@ function Navbar() {
                 }
               }}
             >
-              {sidebarToggle && !isSigningInUser && !isSaveLoading ? (
-                <IoMdClose size={24} className="text-secondary" />
-              ) : (
-                <FiMenu
-                  size={24}
-                  className={`${isSigningInUser || isSaveLoading ? 'text-tertiary cursor-not-allowed' : 'text-secondary'}`}
-                />
-              )}
+              <div className="relative">
+                {sidebarToggle && !isSigningInUser && !isSaveLoading ? (
+                  <IoMdClose size={24} className="text-secondary" />
+                ) : (
+                  <>
+                    <FiMenu
+                      size={24}
+                      className={`${isSigningInUser || isSaveLoading ? 'text-tertiary cursor-not-allowed' : 'text-secondary'}`}
+                    />
+                    {notificationsCount > 0 && (
+                      <span className="absolute top-[-6px] right-[-6px] w-[10px] h-[10px] bg-red-500 rounded-full animate-pulse" />
+                    )}
+                  </>
+                )}
+              </div>
             </Link>
           </div>
         </div>

--- a/src/components/shared/navbar/Navbar.tsx
+++ b/src/components/shared/navbar/Navbar.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import styles from './Navbar.module.css';
+
 import Image from 'next/image'
 import { useLocale, useTranslations } from 'next-intl';
 import Link from 'next/link';
@@ -11,7 +13,6 @@ import { ImSpinner2 } from 'react-icons/im';
 import { IoMdArrowBack, IoMdClose } from 'react-icons/io';
 import { MdHome } from 'react-icons/md';
 
-import styles from './Navbar.module.css';
 import MembershipIcon from '@/components/shared/membership/MembershipIcon'; 
 import Sidebar from '../sidebar/sidebar';
 import { AppContext } from '../../../../context/AppContextProvider';
@@ -22,63 +23,52 @@ function Navbar() {
   const pathname = usePathname();
   const locale = useLocale();
   const t = useTranslations();
+
   const [sidebarToggle, setSidebarToggle] = useState(false);
   const [isHomePage, setIsHomePage] = useState(true);
 
-  const {isSigningInUser, reload, alertMessage, isSaveLoading, userMembership, notificationsCount } = useContext(AppContext);
-
-  useEffect(() => {
-  console.log("Navbar saw notification count:", notificationsCount);
-}, [notificationsCount]);
+  const {
+    isSigningInUser, 
+    reload, 
+    alertMessage, 
+    isSaveLoading, 
+    userMembership, 
+    notificationsCount 
+  } = useContext(AppContext);
 
   // check if the current page is the homepage
   useEffect(() => {
-    const checkHomePage = () => {
-      if (pathname === '/' || pathname === `/${locale}`) {
-        setIsHomePage(true);
-      } else {
-        logger.info(`HomePage Pathname is ${pathname}`);
-        setIsHomePage(false);
-      }
-    };
-    checkHomePage();
-  }, [pathname]);
+    setIsHomePage(pathname === '/' || pathname === `/${locale}`);
+    if (!isHomePage) logger.info(`HomePage Pathname is ${pathname}`);
+  }, [pathname, locale]);
 
-  const handleBackBtn = () => {
-    router.back();
-  };
-
-  const handleMenu = () => {
-    setSidebarToggle(!sidebarToggle);
-  };
-
+  const handleBackBtn = () => router.back();
+  const handleMenu = () => setSidebarToggle(prev => !prev);
   const handleClick = (e: any) => {
     e.preventDefault();
     window.open("https://mapofpi.zapier.app", "_blank", "noopener, noreferrer");
   };
 
+  // Helper JSX for main label in header
+  const headerLabel = alertMessage ? (
+    <div className="alert-message flex items-center justify-center">{alertMessage}</div>
+  ) : isSigningInUser || reload ? (
+    <div className="flex items-center justify-center">
+      <ImSpinner2 className="animate-spin mr-2 ml-1" />
+      {t('SHARED.LOADING_SCREEN_MESSAGE')}
+    </div>
+  ) : (
+    "Map of Pi"
+  );
+
   return (
     <>
       <div className="w-full h-[76.19px] z-500 px-[16px] py-[5px] bg-primary fixed top-0 left-0 right-0">
         <div className="w-full flex justify-between items-center">
-          <div className="flex-1"></div>
+          <div className="flex-1" />
           <div className="text-center text-secondary text-[1.3rem] whitespace-nowrap flex-1">
-          {/* Display alert message with spinner if present, otherwise display 'Map of Pi' */}
-          {alertMessage ? (
-            <div className="alert-message flex items-center justify-center">
-              {alertMessage}
-            </div>
-          ) : (
-            isSigningInUser || reload ? (
-              <div className="flex items-center justify-center">
-                <ImSpinner2 className="animate-spin mr-2 ml-1" /> {/* Spinner Icon */}
-                {t('SHARED.LOADING_SCREEN_MESSAGE')}
-              </div>
-            ) : (
-              "Map of Pi"
-            )
-          )}
-        </div>
+            { headerLabel }
+          </div>
           <div className="flex-1">
             <MembershipIcon category={userMembership} />
           </div>
@@ -141,6 +131,7 @@ function Navbar() {
           </div>
         </div>
       </div>
+
       {sidebarToggle && !isSigningInUser && !isSaveLoading && (
         <Sidebar toggle={sidebarToggle} setToggleDis={setSidebarToggle} />
       )}

--- a/src/components/shared/sidebar/sidebar.tsx
+++ b/src/components/shared/sidebar/sidebar.tsx
@@ -1,4 +1,5 @@
 import styles from './sidebar.module.css';
+import clsx from 'clsx';
 
 import { useTranslations, useLocale } from 'next-intl';
 import { useTheme } from 'next-themes';
@@ -108,6 +109,7 @@ function Sidebar(props: any) {
     include_trust_level_0: false,
   });
   const [isOnlineShoppingEnabled, setOnlineShoppingEnabled] = useState(false);
+  const { notificationsCount } = useContext(AppContext);
 
   useEffect(() => {
     if (!currentUser) {
@@ -417,22 +419,35 @@ function Sidebar(props: any) {
             </div>
           )}
 
-          <div className="mb-2">
+          <div className="mb-2 relative">
             <Link href={`/${locale}/notification`}>
-              <Button
-                label={t('View Notifications')} // Stay consistent with 'View Orders'; TODO - Apply language translation
-                styles={{
-                  color: '#ffc153',
-                  width: '100%',
-                  padding: '10px',
-                  borderRadius: '10px',
-                  fontSize: '18px',
-                }}
-                onClick={() => {
-                  props.setToggleDis(false); // Close sidebar on click
-                }}
-              />
-            </Link>              
+              <div className="relative">
+                <Button
+                  label={t('View Notifications')}
+                  styles={{
+                    color: '#ffc153',
+                    width: '100%',
+                    padding: '10px',
+                    borderRadius: '10px',
+                    fontSize: '18px',
+                  }}
+                  onClick={() => {
+                    props.setToggleDis(false);
+                  }}
+                />
+                  {notificationsCount > 0 && (
+                    <span
+                      className={clsx(
+                        'absolute top-[-6px] right-[-6px] bg-[#ff4d4f] text-[#f6c367] text-xs font-bold px-[8px] py-[2px] border-[2px] border-[#f6c367]',
+                        'rounded-full min-w-[22px] text-center',
+                        notificationsCount > 99 && 'px-[4px] min-w-[28px]'
+                      )}
+                    >
+                      {notificationsCount > 99 ? '99+' : notificationsCount}
+                    </span>
+                  )}
+              </div>
+            </Link>
           </div>
 
           {/* user settings form fields */}

--- a/src/components/shared/sidebar/sidebar.tsx
+++ b/src/components/shared/sidebar/sidebar.tsx
@@ -457,17 +457,17 @@ function Sidebar(props: any) {
                     props.setToggleDis(false);
                   }}
                 />
-                  {notificationsCount > 0 && (
-                    <span
-                      className={clsx(
-                        'absolute top-[-6px] right-[-6px] bg-[#ff4d4f] text-[#f6c367] text-xs font-bold px-[8px] py-[2px] border-[2px] border-[#f6c367]',
-                        'rounded-full min-w-[22px] text-center',
-                        notificationsCount > 99 && 'px-[4px] min-w-[28px]'
-                      )}
-                    >
-                      {notificationsCount > 99 ? '99+' : notificationsCount}
-                    </span>
-                  )}
+                {notificationsCount > 0 && (
+                  <span
+                    className={clsx(
+                      'absolute top-[-6px] right-[-6px] bg-[#ff4d4f] text-[#f6c367] text-xs font-bold px-[8px] py-[2px] border-[2px] border-[#f6c367]',
+                      'rounded-full min-w-[22px] text-center',
+                      notificationsCount > 99 && 'px-[4px] min-w-[28px]'
+                    )}
+                  >
+                    {notificationsCount > 99 ? '99+' : notificationsCount}
+                  </span>
+                )}
               </div>
             </Link>
           </div>

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -305,8 +305,8 @@ export type NotificationType = {
   pi_uid: string;
   is_cleared: boolean;
   reason: string;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt: string;
+  updatedAt: string;
 };
 
 export interface INotification {

--- a/src/constants/types.ts
+++ b/src/constants/types.ts
@@ -357,8 +357,3 @@ export type NotificationType = {
   createdAt: string;
   updatedAt: string;
 };
-
-export interface INotification {
-  is_cleared?: boolean;
-  reason: string;
-};

--- a/src/services/notificationApi.ts
+++ b/src/services/notificationApi.ts
@@ -3,9 +3,15 @@ import { INotification } from '@/constants/types';
 import { getMultipartFormDataHeaders } from '@/utils/api';
 import logger from '../../logger.config.mjs';
 
-export const getNotifications = async (
-  {pi_uid, skip, limit, status}: 
-  {pi_uid: string, skip: number, limit: number, status?: 'cleared' | 'uncleared'}) => {
+export const getNotifications = async ({
+  skip,
+  limit,
+  status
+}: {
+  skip: number;
+  limit: number;
+  status?: 'cleared' | 'uncleared';
+}) => {
   try {
     const headers = getMultipartFormDataHeaders();
 
@@ -16,14 +22,14 @@ export const getNotifications = async (
     if (status) {
       queryParams.append('status', status);
     }
-    
-    const response = await axiosClient.get(`/notifications/${pi_uid}?${queryParams.toString()}`, {
-      headers
+
+    const response = await axiosClient.get(`/notifications?${queryParams.toString()}`, {
+      headers,
     });
-    
+
     if (response.status === 200) {
       logger.info(`Get notifications successful with Status ${response.status}`, {
-        data: response.data
+        data: response.data,
       });
       return response.data;
     } else {
@@ -35,6 +41,7 @@ export const getNotifications = async (
     throw new Error('Failed to get notifications. Please try again later.');
   }
 };
+
 
 export const buildNotification = async (data: INotification) => {
   try {
@@ -69,5 +76,20 @@ export const updateNotification = async (notification_id: string) => {
   } catch (error) {
     logger.error('Update notification encountered an error:', error);
     throw new Error('Failed to update notification. Please try again later.');
+  }
+};
+
+export const getNotificationsCount = async (): Promise<number> => {
+  try {
+    const response = await axiosClient.get('/notifications/count?status=uncleared');
+    if (response.status === 200) {
+      logger.info('Get notification count successful', { data: response.data });
+      return response.data.count;
+    }
+    logger.error(`Get notification count failed with status ${response.status}`);
+    return 0;
+  } catch (error) {
+    logger.error('Get notification count error:', error);
+    return 0;
   }
 };

--- a/src/services/notificationApi.ts
+++ b/src/services/notificationApi.ts
@@ -29,7 +29,6 @@ export const getNotifications = async ({
 
     if (response.status === 200) {
       const { items, count } = response.data;
-
       return {
         items: items as NotificationType[], // cast API response
         count,


### PR DESCRIPTION
We fetch the count from the backend using a new /notifications/count endpoint and sync it through AppContext so it’s globally accessible. The count is displayed as a red badge on both the menu icon and the “View Notifications” button in the sidebar. If the count exceeds 99, we show '99+'. We also removed the unnecessary pi_uid param from the fetch call since it's now handled server-side. Tested and working as expected.