### PR TITLE
Fixed seller item saving bug for expired item

### DIFF
--- a/src/components/shared/Seller/ShopItem.tsx
+++ b/src/components/shared/Seller/ShopItem.tsx
@@ -236,7 +236,6 @@ export const ShopItem: React.FC<{
   };
 
   const handleSave = async () => {
-    setIsSaveLoading(true);
     const duration = Number(formData.duration);
     const today = new Date();
 
@@ -255,6 +254,8 @@ export const ShopItem: React.FC<{
         return null;
       }
     }
+    
+    setIsSaveLoading(true);
 
     const formDataToSend = new FormData();
     // Prepare form data


### PR DESCRIPTION
As per reported bug: 
On click, the save button is disabled temporarily for expired seller item until the Seller Administration screen is refreshed.