### PR TITLE
Language feature display 404 Error on the screen

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1,7 +1,11 @@
-import { createSharedPathnamesNavigation } from 'next-intl/navigation';
-import { locales } from '../i18n/i18n';
+import { createNavigation } from 'next-intl/navigation';
+import { locales, defaultLocale } from '../i18n/i18n';
 
-export const localePrefix = 'as-needed';
+export const localePrefix = 'always';
 
-export const { Link, redirect, usePathname, useRouter } =
-  createSharedPathnamesNavigation({ locales, localePrefix });
+export const { Link, redirect, usePathname, useRouter } = 
+  createNavigation({
+    locales,
+    localePrefix,
+    defaultLocale,
+  });


### PR DESCRIPTION
This PR resolves 404 errors that occurred when changing languages by updating the `localePrefix` in next-intl navigation from 'as-needed' to 'always'.  This ensures that all URLs include the locale segment, providing consistent routing across screens. Routing and sidebar language switching were regression tested accordingly.

**[see commits]**