### PR TITLE
Limit login retries to prevent server load

### DIFF
--- a/context/AppContextProvider.tsx
+++ b/context/AppContextProvider.tsx
@@ -23,8 +23,7 @@ const BASE_DELAY_MS = 5000; // 5s → 15s → 45s
 interface IAppContextProps {
   currentUser: IUser | null;
   setCurrentUser: React.Dispatch<SetStateAction<IUser | null>>;
-  registerUser: () => void;
-  autoLoginUser: () => void;
+  authenticateUser: () => void;
   userMembership: MembershipClassType;
   setUserMembership: React.Dispatch<SetStateAction<MembershipClassType>>;
   isSigningInUser: boolean;
@@ -45,8 +44,7 @@ interface IAppContextProps {
 const initialState: IAppContextProps = {
   currentUser: null,
   setCurrentUser: () => {},
-  registerUser: () => {},
-  autoLoginUser: () => {},
+  authenticateUser: () => {},
   isSigningInUser: false,
   userMembership: MembershipClassType.CASUAL,
   setUserMembership: () => {},
@@ -101,102 +99,7 @@ const AppContextProvider = ({ children }: AppContextProviderProps) => {
     }, 5000);
   };
 
-  const loginWithRetry = async (attempt = 0): Promise<void> => {
-    try {
-      await registerUser();
-      return; // exit function upon successful registration
-  
-    } catch (error: any) {
-      logger.warn(`Login attempt ${attempt + 1} failed:`, error);
-  
-      if (isHardFail(error)) {
-        logger.warn("401/403 Hard login failure. Retry attempt not executed.");
-        throw error;
-      }
-  
-      if (attempt >= MAX_LOGIN_RETRIES) {
-        logger.warn("Max retries reached. Stopping auto-login attempts..");
-        throw error;
-      }
-  
-      // exponential backoff + jitter
-      const backoff = BASE_DELAY_MS * Math.pow(3, attempt);
-      const jitter = Math.random() * 1000;
-      const delay = backoff + jitter;
-  
-      logger.warn(`Retrying login in ${Math.round(delay)}ms..`);
-  
-      await sleep(delay);
-      return loginWithRetry(attempt + 1);
-    }
-  };
-
-  /* Register User via Pi SDK */
-  const registerUser = async () => {
-    logger.info('Starting user registration.');
-
-    if (typeof window !== 'undefined' && window.Pi?.initialized) {
-      try {
-        setIsSigningInUser(true);
-        const pioneerAuth: AuthResult = await window.Pi.authenticate([
-          'username', 
-          'payments', 
-          'wallet_address'
-        ], onIncompletePaymentFound);
-
-        // Send accessToken to backend
-        const res = await axiosClient.post(
-          "/users/authenticate", 
-          {}, // empty body
-          {
-            headers: {
-              Authorization: `Bearer ${pioneerAuth.accessToken}`,
-            },
-          }
-        );
-
-        if (res.status === 200) {
-          setAuthToken(res.data?.token);
-          setCurrentUser(res.data.user);
-          setUserMembership(res.data.membership_class);
-          logger.info('User authenticated successfully.');
-        } else {
-          setCurrentUser(null);
-          logger.error('User authentication failed.');
-        }
-      } catch (error) {
-        logger.error('Error during user registration:', error);
-      } finally {
-        setTimeout(() => setIsSigningInUser(false), 2500);
-      }
-    } else {
-      logger.error('PI SDK failed to initialize.');
-    }
-  };
-
-  /* Attempt Auto Login (fallback to Pi auth) */
-  const autoLoginUser = async () => {
-    logger.info('Attempting to auto-login user.');
-    try {
-      setIsSigningInUser(true);
-      const res = await axiosClient.get('/users/me');
-
-      if (res.status === 200) {
-        logger.info('Auto-login successful.');
-        setCurrentUser(res.data.user);
-        setUserMembership(res.data.membership_class);
-      } else {
-        logger.warn('Auto-login failed.');
-        setCurrentUser(null);
-      }
-    } catch (error) {
-      logger.error('Auto login unresolved; attempting Pi SDK authentication:', error);
-      await loginWithRetry();
-    } finally {
-      setTimeout(() => setIsSigningInUser(false), 2500);
-    }
-  };
-
+  /* Pi SDK helper functions */
   const loadPiSdk = (): Promise<typeof window.Pi> => {
     return new Promise((resolve, reject) => {
       const script = document.createElement('script');
@@ -224,6 +127,94 @@ const AppContextProvider = ({ children }: AppContextProviderProps) => {
     return Pi;
   };
 
+  /* Login helper functions */
+  const autoLoginProcess = async (): Promise<boolean> => {
+    try {
+      const res = await axiosClient.get("/users/me");
+      if (res.status === 200) {
+        setCurrentUser(res.data.user);
+        setUserMembership(res.data.membership_class);
+        return true;
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  };
+
+  const piSdkLoginProcess = async (): Promise<boolean> => {
+    try {
+      const Pi = await ensurePiSdkLoaded();
+      const pioneerAuth: AuthResult = await Pi.authenticate(
+        ["username", "payments", "wallet_address"],
+        onIncompletePaymentFound
+      );
+
+      // Send accessToken to backend
+      const res = await axiosClient.post(
+        "/users/authenticate",
+        {},
+        {
+          headers: { Authorization: `Bearer ${pioneerAuth.accessToken}` },
+        }
+      );
+
+      setAuthToken(res.data?.token);
+      setCurrentUser(res.data.user);
+      setUserMembership(res.data.membership_class);
+      return true;
+    } catch (error: any) {
+      if (isHardFail(error)) throw error; // 401/403 must break retry loop
+      return false; // soft failures become retry'able
+    }
+  };
+
+  const authenticateUser = async (attempt = 0): Promise<void> => {
+    if (isSigningInUser) return;
+
+    setIsSigningInUser(true);
+
+    try {
+      // Process #1 : Attempt Auto-Login
+      const autoLoggedIn = await autoLoginProcess();
+      if (autoLoggedIn) {
+        logger.info("Auto-login successful.");
+        return;
+      }
+
+      // Process #2 : Fallback to Pi SDK login and registration
+      const sdkLoggedIn = await piSdkLoginProcess();
+      if (sdkLoggedIn) {
+        logger.info("Pi SDK login successful.");
+        return;
+      }
+
+      // Process #3. Continue retry logic for 'soft failures'
+      throw new Error("Pi SDK login failed");
+    } catch (error: any) {
+      if (isHardFail(error)) {
+        logger.warn("401/403 Hard login failure. Stopping retries.");
+        throw error;
+      }
+
+      if (attempt >= MAX_LOGIN_RETRIES) {
+        logger.warn("Max retries reached. Stopping retries.");
+        throw error;
+      }
+
+      // exponential backoff + jitter
+      const backoff = BASE_DELAY_MS * Math.pow(3, attempt);
+      const jitter = Math.random() * 1000;
+      const delay = backoff + jitter;
+
+      logger.warn(`Auth attempt ${attempt + 1} failed. Retrying in ${Math.round(delay)}ms..`);
+      await sleep(delay);
+      return authenticateUser(attempt + 1);
+    } finally {
+      setTimeout(() => setIsSigningInUser(false), 2000);
+    }
+  };
+
   useEffect(() => {
     logger.info('AppContextProvider mounted.');
 
@@ -238,7 +229,7 @@ const AppContextProvider = ({ children }: AppContextProviderProps) => {
       })
       .catch(err => logger.error('Pi SDK load/ init error:', err));
 
-    autoLoginUser();
+    authenticateUser();
   }, [isSigningInUser, currentUser]);
 
   useEffect(() => {
@@ -268,8 +259,7 @@ const AppContextProvider = ({ children }: AppContextProviderProps) => {
       value={{ 
         currentUser, 
         setCurrentUser, 
-        registerUser, 
-        autoLoginUser, 
+        authenticateUser, 
         isSigningInUser, 
         userMembership,
         setUserMembership,

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -34,13 +34,15 @@ export default async function LocaleLayout({
 
   return (
     <NextIntlClientProvider locale={locale} messages={messages}>
-      <Providers>
-        <Navbar />
-        <div className={`pt-[80px] ${lato.className}`}>
-          {children}
-        </div>
-        <ToastContainer />
-      </Providers>
+      <div className={`bg-background text-black ${lato.className}`}>
+        <Providers>
+          <Navbar />
+          <div className="pt-[80px]">
+            {children}
+          </div>
+          <ToastContainer />
+        </Providers>
+      </div>
     </NextIntlClientProvider>
   );
 }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -42,7 +42,7 @@ export default function Page({ params }: { params: { locale: string } }) {
   const {
     isSigningInUser,
     currentUser,
-    autoLoginUser,
+    authenticateUser,
     reload,
     setReload
   } = useContext(AppContext);
@@ -55,7 +55,7 @@ export default function Page({ params }: { params: { locale: string } }) {
     }
     setReload(false);
     setSearchCenterPopup(false);
-    checkAndAutoLoginUser(currentUser, autoLoginUser);
+    checkAndAutoLoginUser(currentUser, authenticateUser);
 
     const getUserSettingsData = async (): Promise<{ needsSearchCenter: boolean }> => {
       try {

--- a/src/app/[locale]/seller/registration/page.tsx
+++ b/src/app/[locale]/seller/registration/page.tsx
@@ -43,7 +43,7 @@ const SellerRegistrationForm = () => {
   const t = useTranslations();
   const placeholderSeller = itemData.seller;
 
-  const { currentUser, autoLoginUser, showAlert, userMembership } = useContext(AppContext);
+  const { currentUser, authenticateUser, showAlert, userMembership } = useContext(AppContext);
 
   type IFormData = {
     sellerName: string;
@@ -88,7 +88,7 @@ const SellerRegistrationForm = () => {
   
   // Fetch seller data and user settings on component mount
   useEffect(() => {
-    checkAndAutoLoginUser(currentUser, autoLoginUser);
+    checkAndAutoLoginUser(currentUser, authenticateUser);
 
     const getSellerData = async () => {
       try {

--- a/src/app/[locale]/seller/reviews/[id]/edit/page.tsx
+++ b/src/app/[locale]/seller/reviews/[id]/edit/page.tsx
@@ -20,7 +20,7 @@ export default function EditReviewPage({ params }: { params: { id: string } }) {
   const [originalReview, setOriginalReview] = useState<IReviewOutput | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const { currentUser, reload, setReload, autoLoginUser } = useContext(AppContext);
+  const { currentUser, reload, setReload, authenticateUser } = useContext(AppContext);
 
   // Editable fields
   const [rating, setRating] = useState<number | null>(null);
@@ -30,7 +30,7 @@ export default function EditReviewPage({ params }: { params: { id: string } }) {
   const [isSaveEnabled, setIsSaveEnabled] = useState(false);
 
   useEffect(() => {
-    checkAndAutoLoginUser(currentUser, autoLoginUser);
+    checkAndAutoLoginUser(currentUser, authenticateUser);
 
     const getReviewData = async () => {
       try {

--- a/src/app/[locale]/seller/reviews/[id]/page.tsx
+++ b/src/app/[locale]/seller/reviews/[id]/page.tsx
@@ -38,14 +38,14 @@ function SellerReviews({
   const [error, setError] = useState<string | null>(null);
   const [isSaveEnabled, setIsSaveEnabled] = useState(false);
   const [userFallbackImage, setUserFallbackImage] = useState<string | null>(null);
-  const { currentUser, reload, setReload, autoLoginUser } = useContext(AppContext);
+  const { currentUser, reload, setReload, authenticateUser } = useContext(AppContext);
   
   const inputRef = useRef<HTMLInputElement>(null);
   const [searchBarValue, setSearchBarValue] = useState('');
   const [toUser, setToUser] = useState('');
 
   useEffect(() => {
-    checkAndAutoLoginUser(currentUser, autoLoginUser);
+    checkAndAutoLoginUser(currentUser, authenticateUser);
     fetchUserReviews(userId);
 
     const loadUserImage = async () => {

--- a/src/app/[locale]/seller/reviews/feedback/[id]/page.tsx
+++ b/src/app/[locale]/seller/reviews/feedback/[id]/page.tsx
@@ -42,7 +42,7 @@ export default function ReplyToReviewPage({ params }: ReplyToReviewPageProps) {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [userFallbackImage, setUserFallbackImage] = useState<string | null>(null);
-  const { currentUser, autoLoginUser, reload, setReload } = useContext(AppContext);
+  const { currentUser, authenticateUser, reload, setReload } = useContext(AppContext);
 
   const processReviews = (data: IReviewOutput[]): ReviewInt[] => {
     return data.map((feedback) => {
@@ -66,7 +66,7 @@ export default function ReplyToReviewPage({ params }: ReplyToReviewPageProps) {
   };
   
   useEffect(() => {
-    checkAndAutoLoginUser(currentUser, autoLoginUser);
+    checkAndAutoLoginUser(currentUser, authenticateUser);
 
     const getReviewData = async () => {
       try {

--- a/src/app/[locale]/seller/sale-items/[id]/page.tsx
+++ b/src/app/[locale]/seller/sale-items/[id]/page.tsx
@@ -49,7 +49,7 @@ export default function BuyFromSellerForm({
 
   const {
     currentUser,
-    autoLoginUser,
+    authenticateUser,
     reload,
     setReload,
     showAlert
@@ -79,7 +79,7 @@ export default function BuyFromSellerForm({
   };
 
   useEffect(() => {
-    checkAndAutoLoginUser(currentUser, autoLoginUser);
+    checkAndAutoLoginUser(currentUser, authenticateUser);
 
     const getSellerData = async () => {
       try {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -77,7 +77,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           `,
         }} />
       </head>
-      <body className={`bg-background text-black`}>
+      <body>
         {children}
       </body>
     </html>

--- a/src/components/shared/map/MapCenter.tsx
+++ b/src/components/shared/map/MapCenter.tsx
@@ -45,7 +45,7 @@ const MapCenter = ({ entryType }: MapCenterProps) => {
     lng: 19.944544,
     lat: 50.064192,
   });
-  const { currentUser, autoLoginUser } = useContext(AppContext);
+  const { currentUser, authenticateUser } = useContext(AppContext);
   const mapRef = useRef<L.Map | null>(null);
 
   const isSigningInUser = false;
@@ -53,7 +53,7 @@ const MapCenter = ({ entryType }: MapCenterProps) => {
   useEffect(() => {
     if (!currentUser) {
       logger.info("User not logged in; attempting auto-login..");
-      autoLoginUser();
+      authenticateUser();
     }
 
     // Fetch the map center from the backend if the user is authenticated

--- a/src/components/shared/sidebar/sidebar.tsx
+++ b/src/components/shared/sidebar/sidebar.tsx
@@ -91,7 +91,7 @@ function Sidebar(props: any) {
     { target: 'include_trust_level_0', title: 'Trust-o-meter 0%' },
   ];
 
-  const { currentUser, autoLoginUser, setReload, showAlert } = useContext(AppContext);
+  const { currentUser, authenticateUser, setReload, showAlert } = useContext(AppContext);
   const [dbUserSettings, setDbUserSettings] = useState<IUserSettings | null>(null);
   // Initialize state with appropriate types
   const [formData, setFormData] = useState<{
@@ -135,7 +135,7 @@ function Sidebar(props: any) {
   useEffect(() => {
     if (!currentUser) {
       logger.info('User not logged in; attempting auto-login..');
-      autoLoginUser();
+      authenticateUser();
     }
 
     const getUserSettingsData = async () => {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,9 +1,9 @@
 import { IUser } from '@/constants/types';
 import logger from '../../logger.config.mjs';
 
-export const checkAndAutoLoginUser = (currentUser:IUser | null, autoLoginUser:()=>void) => {
+export const checkAndAutoLoginUser = (currentUser:IUser | null, authenticateUser:()=>void) => {
   if (!currentUser) {
     logger.info("User not logged in, attempting to auto-login..");
-    autoLoginUser();
+    authenticateUser();
   } 
 }


### PR DESCRIPTION
Modded `AppContextProvider.tsx` as follows →

+ Pi SDK is initialized only once per session; `ensurePiSdkLoaded` now guards against multiple script injections and repeated initialization.
+ Login retries are now capped; `loginWithRetry` handles automatic retrying with exponential backoff + jitter.
+ Maximum retries are capped at 3 attempts to prevent overwhelming the server.
+ _Hard failures_ stop retries immediately; HTTP 401/403 responses are detected and stop further automatic login attempts, requiring user action to retry.

**[see commits]**
