### PR TITLE
Search Center screen resulting in 404 Error

### DIFF
--- a/src/components/shared/sidebar/sidebar.tsx
+++ b/src/components/shared/sidebar/sidebar.tsx
@@ -421,7 +421,7 @@ function Sidebar(props: any) {
                 fontSize: '18px',
               }}
               onClick={() => {
-                router.push(`/${locale}/map-center?entryType=search`);
+                router.push(`/map-center?entryType=search`);
                 props.setToggleDis(false); // Close sidebar on click
               }}
             />

--- a/src/components/shared/sidebar/sidebar.tsx
+++ b/src/components/shared/sidebar/sidebar.tsx
@@ -421,7 +421,7 @@ function Sidebar(props: any) {
                 fontSize: '18px',
               }}
               onClick={() => {
-                router.push(`/map-center?entryType=search`);
+                router.push('/map-center?entryType=search');
                 props.setToggleDis(false); // Close sidebar on click
               }}
             />


### PR DESCRIPTION
The Search Center button was generating URLs like /en/en/map-center, causing a 404.  This happened because the code manually added the locale (e.g., /${locale}/map-center) even though the new next-intl router already adds the locale automatically.  The appended `locale` has been removed.

**[see commits]**