### PR TITLE
fix(i18n): update VIEW_ORDERS_LABEL to 'View Sent Orders'

### DIFF
--- a/messages/en-GB.json
+++ b/messages/en-GB.json
@@ -15,7 +15,7 @@
     }
   },
   "SIDE_NAVIGATION": {
-    "VIEW_ORDERS_LABEL": "View Orders",
+    "VIEW_ORDERS_LABEL": "View Sent Orders",
     "USER_PREFERENCES_HEADER": "User Preferences",
     "PERSONALIZATION_SUBHEADER": "Personalisation",
     "LANGUAGES": "Languages",

--- a/messages/en.json
+++ b/messages/en.json
@@ -15,7 +15,7 @@
     }
   },
   "SIDE_NAVIGATION": {
-    "VIEW_ORDERS_LABEL": "View Orders",
+    "VIEW_ORDERS_LABEL": "View Sent Orders",
     "USER_PREFERENCES_HEADER": "User Preferences",
     "PERSONALIZATION_SUBHEADER": "Personalization",
     "LANGUAGES": "Languages",


### PR DESCRIPTION
## Changes
- Updated "View Orders" button label to **"View Sent Orders"** in the User Preferences screen.

## Files Changed
- `messages/en.json`
- `messages/en-GB.json`