### PR TITLE
fix: preserve aspect ratio of membership icons at consistent height

### DIFF
--- a/src/components/shared/membership/MembershipIcon.tsx
+++ b/src/components/shared/membership/MembershipIcon.tsx
@@ -7,10 +7,12 @@ import DoubleGoldIcon from "../../../../public/images/membership/Member_icon_dou
 import TripleGoldIcon from "../../../../public/images/membership/Member_icon_triple_gold.svg"
 import { MembershipClassType } from '@/constants/types'
 
-function MembershipIcon({ category, className, styleComponent }: { 
-  category: MembershipClassType, 
-  className?: string, 
-  styleComponent?: any }) {
+function MembershipIcon({ category, className, styleComponent, size = 17 }: {
+  category: MembershipClassType,
+  className?: string,
+  styleComponent?: any,
+  size?: number
+}) {
   const HandleMembership = (category: MembershipClassType) => {
     switch (category) {
       case MembershipClassType.TRIPLE_GOLD:
@@ -29,20 +31,22 @@ function MembershipIcon({ category, className, styleComponent }: {
   }
 
   const icon = HandleMembership(category);
-
   if (!icon) return null; // Don't render anything for casual members
+
+  const aspectRatio = icon.width / icon.height;
+  const width = Math.round(aspectRatio * size);
 
   return (
     <div
     className={`relative inline-block ${className || ''}`}
     style={{
-      height: '17px',
-      width: `${Math.round((icon.width / icon.height) * 17)}px`,
-        flexShrink: 0,
-        ...styleComponent
+      height: `${size}px`,
+      width: `${width}px`,
+      flexShrink: 0,
+      ...styleComponent
     }}
     >
-      <Image src={icon} alt={category} fill style={{ objectFit: 'contain' }}/>
+    <Image src={icon} alt={category} fill style={{ objectFit: 'contain' }}/>
     </div>
   )
 }

--- a/src/components/shared/membership/MembershipIcon.tsx
+++ b/src/components/shared/membership/MembershipIcon.tsx
@@ -33,7 +33,15 @@ function MembershipIcon({ category, className, styleComponent }: {
   if (!icon) return null; // Don't render anything for casual members
 
   return (
-    <div className={`w-7 h-5 relative float-right ${className || ''}`} style={styleComponent}>
+    <div
+    className={`relative inline-block ${className || ''}`}
+    style={{
+      height: '17px',
+      width: `${Math.round((icon.width / icon.height) * 17)}px`,
+        flexShrink: 0,
+        ...styleComponent
+    }}
+    >
       <Image src={icon} alt={category} fill style={{ objectFit: 'contain' }}/>
     </div>
   )

--- a/src/components/shared/navbar/Navbar.tsx
+++ b/src/components/shared/navbar/Navbar.tsx
@@ -69,7 +69,7 @@ function Navbar() {
           <div className="text-center text-secondary text-[1.3rem] whitespace-nowrap flex-1">
             { headerLabel }
           </div>
-          <div className="flex-1">
+          <div className="flex-1 flex justify-end">
             <MembershipIcon category={userMembership} />
           </div>
         </div>


### PR DESCRIPTION
- Remove fixed w-7 container that was squashing double and triple gold icons
- Calculate width proportionally from SVG natural dimensions
- Set consistent height of 17px across all membership icon types
- Add flexShrink: 0 to prevent icons shrinking on narrow screens
- Remove float-right which had no effect in flex contexts

EDIT - Updated based on code review feedback:

- Add `size` prop with default of 17px making the component reusable across different contexts
- Extract `aspectRatio` and `width` into variables for better readability
- Restore navbar icon right alignment via `flex justify-end` on parent container instead of `float-right`
- Fix indentation and formatting