### PR TITLE
Automatic scroll on pressing header toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "lodash": "^4.18.1",
         "loglevel": "^1.9.1",
         "next": "^14.2.28",
-        "next-intl": "^4.5.5",
+        "next-intl": "^4.12.0",
         "next-logger": "^4.0.0",
         "next-themes": "^0.3.0",
         "ngx-logger": "^5.0.12",
@@ -12331,16 +12331,6 @@
         }
       }
     },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/next-logger": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/next-logger/-/next-logger-4.0.0.tgz",
@@ -15084,22 +15074,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.18.1",
     "loglevel": "^1.9.1",
     "next": "^14.2.28",
-    "next-intl": "^4.5.5",
+    "next-intl": "^4.12.0",
     "next-logger": "^4.0.0",
     "next-themes": "^0.3.0",
     "ngx-logger": "^5.0.12",

--- a/src/components/shared/Seller/ToggleCollapse.tsx
+++ b/src/components/shared/Seller/ToggleCollapse.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { FaChevronDown } from 'react-icons/fa6';
 
 interface ToggleCollapseProps {
@@ -9,17 +9,31 @@ interface ToggleCollapseProps {
 
 function ToggleCollapse({ children, header, open = false }: ToggleCollapseProps) {
   const [toggle, setToggle] = useState<boolean>(open);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const handleToggle = () => {
+    const opening = !toggle;
+    setToggle(opening);
+
+    if (opening) {
+      setTimeout(() => {
+        wrapperRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }, 50);
+    }
+  };
 
   return (
-    <div className="mb-2">
-      <div className="flex items-center justify-center gap-4 cursor-pointer mb-2" onClick={() => setToggle(!toggle)}>
+    <div className="mb-2" ref={wrapperRef}>
+      <div
+        className="flex items-center justify-center gap-4 cursor-pointer mb-2"
+        onClick={handleToggle}>
         <h2 className="font-bold">{header}</h2>
         <FaChevronDown
           size={13}
           className={`text-[#000000] ${toggle && 'rotate-90'}`}
         />
       </div>
-      {toggle && children}
+      {toggle && <div>{children}</div>}
     </div>
   );
 }

--- a/src/components/shared/Seller/ToggleCollapse.tsx
+++ b/src/components/shared/Seller/ToggleCollapse.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { FaChevronDown } from 'react-icons/fa6';
 
 interface ToggleCollapseProps {
@@ -10,16 +10,75 @@ interface ToggleCollapseProps {
 function ToggleCollapse({ children, header, open = false }: ToggleCollapseProps) {
   const [toggle, setToggle] = useState<boolean>(open);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  // Tracks user-triggered opens so default-open sections and closes do not scroll.
+  const scrollAfterOpenRef = useRef(false);
+
+  const getScrollableParent = (element: HTMLElement | null) => {
+    let parent = element?.parentElement;
+
+    while (parent) {
+      const { overflowY } = window.getComputedStyle(parent);
+      const canScroll = /(auto|scroll)/.test(overflowY);
+
+      // Some ToggleCollapse instances live inside the sidebar, which scrolls separately from the page.
+      if (canScroll && parent.scrollHeight > parent.clientHeight) {
+        return parent;
+      }
+
+      parent = parent.parentElement;
+    }
+
+    return null;
+  };
+
+  useEffect(() => {
+    if (!toggle || !scrollAfterOpenRef.current) {
+      return;
+    }
+
+    scrollAfterOpenRef.current = false;
+
+    // Wait one frame so the opened content exists before measuring visibility.
+    const animationFrame = window.requestAnimationFrame(() => {
+      const content = contentRef.current;
+      const wrapper = wrapperRef.current;
+
+      if (!content || !wrapper) {
+        return;
+      }
+
+      const scrollContainer = getScrollableParent(wrapper);
+      const contentRect = content.getBoundingClientRect();
+      const viewportBottom = scrollContainer
+        ? scrollContainer.getBoundingClientRect().bottom
+        : window.innerHeight;
+      // Reveal only the first bit of content instead of jumping the header to the top.
+      const firstLineBottom = contentRect.top + Math.min(contentRect.height, 40);
+      const scrollMargin = 12;
+      const scrollAmount = firstLineBottom - viewportBottom + scrollMargin;
+
+      if (scrollAmount <= 0) {
+        return;
+      }
+
+      if (scrollContainer) {
+        scrollContainer.scrollBy({ top: scrollAmount, behavior: 'smooth' });
+        return;
+      }
+
+      window.scrollBy({ top: scrollAmount, behavior: 'smooth' });
+    });
+
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, [toggle]);
 
   const handleToggle = () => {
-    const opening = !toggle;
-    setToggle(opening);
-
-    if (opening) {
-      setTimeout(() => {
-        wrapperRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      }, 50);
-    }
+    setToggle((currentToggle) => {
+      const opening = !currentToggle;
+      scrollAfterOpenRef.current = opening;
+      return opening;
+    });
   };
 
   return (
@@ -33,7 +92,7 @@ function ToggleCollapse({ children, header, open = false }: ToggleCollapseProps)
           className={`text-[#000000] ${toggle && 'rotate-90'}`}
         />
       </div>
-      {toggle && <div>{children}</div>}
+      {toggle && <div ref={contentRef}>{children}</div>}
     </div>
   );
 }


### PR DESCRIPTION
Modified the togglecollapse component adding useRef and scrollIntoView so that when a section is opened, the page automatically scrolls up to show the header and its content.