### PR TITLE
Order UI hardening against edge cases

### DIFF
--- a/src/app/[locale]/seller/order-fulfillment/[id]/page.tsx
+++ b/src/app/[locale]/seller/order-fulfillment/[id]/page.tsx
@@ -13,6 +13,7 @@ import {
   fetchSellerOrders
 } from "@/services/orderApi";
 import { resolveDate } from "@/utils/date";
+import { formatPiAmount } from "@/utils/order";
 import {
   getFulfillmentMethodOptions,
   translateSellerCategory
@@ -162,7 +163,7 @@ export default function OrderItemPage({ params, searchParams }: { params: { id: 
                   label={t('SCREEN.SELLER_ORDER_FULFILLMENT.ORDER_HEADER_ITEMS_FEATURE.TOTAL_PRICE_LABEL')}
                   name="price"
                   type="number"
-                  value={currentOrder.total_amount.$numberDecimal || currentOrder.total_amount.$numberDecimal.toString()}
+                  value={formatPiAmount(currentOrder.total_amount)}
                   disabled={true}
                 />
                 <p className="text-gray-500 text-sm">Pi</p>
@@ -229,7 +230,7 @@ export default function OrderItemPage({ params, searchParams }: { params: { id: 
                     label={t('SCREEN.BUY_FROM_SELLER.ONLINE_SHOPPING.SELLER_ITEMS_FEATURE.PRICE_LABEL') + ':'}
                     name="price"
                     type="number"
-                    value={item.subtotal.$numberDecimal || item.subtotal.$numberDecimal.toString()}
+                    value={formatPiAmount(item.subtotal)}
                     disabled={true}
                   />
                   <p className="text-gray-500 text-sm">Pi</p>

--- a/src/app/[locale]/user/order-item/[id]/page.tsx
+++ b/src/app/[locale]/user/order-item/[id]/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/constants/types";
 import { fetchOrderById } from "@/services/orderApi";
 import { resolveDate } from "@/utils/date";
+import { formatPiAmount, getSellerName } from "@/utils/order";
 import { 
   getFulfillmentMethodOptions, 
   translateOrderItemStatusType, 
@@ -42,7 +43,7 @@ export default function ReviewOrderItemPage({ params, searchParams }: { params: 
         if (data) {
           setCurrentOrder(data.order);
           setOrderItems(data.orderItems);
-          setSellerName(data.order.seller_id.name);
+          setSellerName(getSellerName(data.order?.seller_id));
         } else {
           setCurrentOrder(null);
           setOrderItems([]);
@@ -102,7 +103,7 @@ export default function ReviewOrderItemPage({ params, searchParams }: { params: 
                   label={t('SCREEN.SELLER_ORDER_FULFILLMENT.ORDER_HEADER_ITEMS_FEATURE.TOTAL_PRICE_LABEL') + ':'}
                   name="Total price"
                   type="number"
-                  value={currentOrder.total_amount.$numberDecimal || currentOrder.total_amount.$numberDecimal.toString()}
+                  value={formatPiAmount(currentOrder.total_amount)}
                   disabled={true}
                 />
                 <p className="text-gray-500 text-sm">Pi</p>
@@ -171,7 +172,7 @@ export default function ReviewOrderItemPage({ params, searchParams }: { params: 
                     label={t('SCREEN.BUY_FROM_SELLER.ONLINE_SHOPPING.SELLER_ITEMS_FEATURE.PRICE_LABEL') + ':'}
                     name="price"
                     type="number"
-                    value={item.subtotal.$numberDecimal || item.subtotal.$numberDecimal.toString()}
+                    value={formatPiAmount(item.subtotal)}
                     disabled={true}
                   />
                   <p className="text-gray-500 text-sm">Pi</p>

--- a/src/app/[locale]/user/order-item/[id]/page.tsx
+++ b/src/app/[locale]/user/order-item/[id]/page.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/constants/types";
 import { fetchOrderById } from "@/services/orderApi";
 import { resolveDate } from "@/utils/date";
-import { formatPiAmount, getSellerName } from "@/utils/order";
+import { formatPiAmount } from "@/utils/order";
 import { 
   getFulfillmentMethodOptions, 
   translateOrderItemStatusType, 
@@ -43,7 +43,7 @@ export default function ReviewOrderItemPage({ params, searchParams }: { params: 
         if (data) {
           setCurrentOrder(data.order);
           setOrderItems(data.orderItems);
-          setSellerName(getSellerName(data.order?.seller_id));
+          setSellerName(data.order?.seller_id?.name || '');
         } else {
           setCurrentOrder(null);
           setOrderItems([]);

--- a/src/app/[locale]/user/order-review/page.tsx
+++ b/src/app/[locale]/user/order-review/page.tsx
@@ -9,7 +9,7 @@ import { PartialOrderType, OrderStatusType } from '@/constants/types';
 import { fetchBuyerOrders } from '@/services/orderApi';
 import { useScrollablePagination } from '@/hooks/useScrollablePagination';
 import { resolveDate } from '@/utils/date';
-import { formatPiAmount, getSellerName } from '@/utils/order';
+import { formatPiAmount } from '@/utils/order';
 import { translateOrderStatusType } from '@/utils/translate';
 
 import { AppContext } from '../../../../../context/AppContextProvider';
@@ -153,7 +153,7 @@ export default function OrderReviewPage() {
                       label={t('SCREEN.SELLER_ORDER_FULFILLMENT.ORDER_HEADER_ITEMS_FEATURE.SELLER_LABEL') + ':'}
                       name="name"
                       type="text"
-                      value={getSellerName(item.seller_id)}
+                      value={item.seller_id?.name || ''}
                       disabled={true}
                     />
                   </div>

--- a/src/app/[locale]/user/order-review/page.tsx
+++ b/src/app/[locale]/user/order-review/page.tsx
@@ -9,6 +9,7 @@ import { PartialOrderType, OrderStatusType } from '@/constants/types';
 import { fetchBuyerOrders } from '@/services/orderApi';
 import { useScrollablePagination } from '@/hooks/useScrollablePagination';
 import { resolveDate } from '@/utils/date';
+import { formatPiAmount, getSellerName } from '@/utils/order';
 import { translateOrderStatusType } from '@/utils/translate';
 
 import { AppContext } from '../../../../../context/AppContextProvider';
@@ -152,7 +153,7 @@ export default function OrderReviewPage() {
                       label={t('SCREEN.SELLER_ORDER_FULFILLMENT.ORDER_HEADER_ITEMS_FEATURE.SELLER_LABEL') + ':'}
                       name="name"
                       type="text"
-                      value={item.seller_id.name}
+                      value={getSellerName(item.seller_id)}
                       disabled={true}
                     />
                   </div>
@@ -163,7 +164,7 @@ export default function OrderReviewPage() {
                         label={t('SCREEN.SELLER_ORDER_FULFILLMENT.ORDER_HEADER_ITEMS_FEATURE.TOTAL_PRICE_LABEL') + ':'}
                         name="price"
                         type="number"
-                        value={item.total_amount.$numberDecimal || item.total_amount.$numberDecimal.toString()}
+                        value={formatPiAmount(item.total_amount)}
                         disabled={true}
                       />
                       <p className="text-gray-500 text-sm">Pi</p>

--- a/src/components/shared/Seller/OrderList.tsx
+++ b/src/components/shared/Seller/OrderList.tsx
@@ -6,6 +6,7 @@ import { Input } from "../Forms/Inputs/Inputs";
 import { OrderStatusType, PartialOrderType } from "@/constants/types";
 import { fetchSellerOrders } from "@/services/orderApi";
 import { resolveDate } from "@/utils/date";
+import { formatPiAmount, getBuyerUsername } from "@/utils/order";
 import logger from '../../../../logger.config.mjs';
 
 export const ListOrder: React.FC<{
@@ -54,7 +55,7 @@ export const ListOrder: React.FC<{
                   label={t('SHARED.PIONEER_LABEL') + ':'}
                   name="name"
                   type="text"
-                  value={item.buyer_id.pi_username}
+                  value={getBuyerUsername(item.buyer_id)}
                   disabled={true}
                 />
               </div>
@@ -65,7 +66,7 @@ export const ListOrder: React.FC<{
                     label={t('SCREEN.SELLER_ORDER_FULFILLMENT.ORDER_HEADER_ITEMS_FEATURE.TOTAL_PRICE_LABEL') + ':'}
                     name="price"
                     type="number"
-                    value={item.total_amount.$numberDecimal || item.total_amount.$numberDecimal.toString()}
+                    value={formatPiAmount(item.total_amount)}
                     disabled={true}
                   />
                   <p className="text-gray-500 text-sm">Pi</p>

--- a/src/components/shared/Seller/OrderList.tsx
+++ b/src/components/shared/Seller/OrderList.tsx
@@ -6,7 +6,7 @@ import { Input } from "../Forms/Inputs/Inputs";
 import { OrderStatusType, PartialOrderType } from "@/constants/types";
 import { fetchSellerOrders } from "@/services/orderApi";
 import { resolveDate } from "@/utils/date";
-import { formatPiAmount, getBuyerUsername } from "@/utils/order";
+import { formatPiAmount } from "@/utils/order";
 import logger from '../../../../logger.config.mjs';
 
 export const ListOrder: React.FC<{
@@ -55,7 +55,7 @@ export const ListOrder: React.FC<{
                   label={t('SHARED.PIONEER_LABEL') + ':'}
                   name="name"
                   type="text"
-                  value={getBuyerUsername(item.buyer_id)}
+                  value={item.buyer_id?.pi_username || ''}
                   disabled={true}
                 />
               </div>

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -1,5 +1,5 @@
-// Order payloads can include legacy or partially populated values, so these
-// helpers keep display-only fields from crashing the order screens.
+// Order payloads can include legacy values, so this helper keeps display-only
+// amount fields from crashing the order screens.
 
 type DecimalValue =
   | number
@@ -8,15 +8,6 @@ type DecimalValue =
   | undefined
   | {
       $numberDecimal?: number | string | null;
-    };
-
-type OrderPartyValue =
-  | string
-  | null
-  | undefined
-  | {
-      name?: string | null;
-      pi_username?: string | null;
     };
 
 export const formatPiAmount = (amount: DecimalValue): string => {
@@ -28,14 +19,4 @@ export const formatPiAmount = (amount: DecimalValue): string => {
 
   const decimal = amount.$numberDecimal;
   return decimal === null || decimal === undefined ? '' : decimal.toString();
-};
-
-export const getSellerName = (seller: OrderPartyValue): string => {
-  if (!seller || typeof seller === 'string') return '';
-  return seller.name ?? '';
-};
-
-export const getBuyerUsername = (buyer: OrderPartyValue): string => {
-  if (!buyer || typeof buyer === 'string') return '';
-  return buyer.pi_username ?? '';
 };

--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -1,0 +1,41 @@
+// Order payloads can include legacy or partially populated values, so these
+// helpers keep display-only fields from crashing the order screens.
+
+type DecimalValue =
+  | number
+  | string
+  | null
+  | undefined
+  | {
+      $numberDecimal?: number | string | null;
+    };
+
+type OrderPartyValue =
+  | string
+  | null
+  | undefined
+  | {
+      name?: string | null;
+      pi_username?: string | null;
+    };
+
+export const formatPiAmount = (amount: DecimalValue): string => {
+  if (amount === null || amount === undefined) return '';
+
+  if (typeof amount === 'number' || typeof amount === 'string') {
+    return amount.toString();
+  }
+
+  const decimal = amount.$numberDecimal;
+  return decimal === null || decimal === undefined ? '' : decimal.toString();
+};
+
+export const getSellerName = (seller: OrderPartyValue): string => {
+  if (!seller || typeof seller === 'string') return '';
+  return seller.name ?? '';
+};
+
+export const getBuyerUsername = (buyer: OrderPartyValue): string => {
+  if (!buyer || typeof buyer === 'string') return '';
+  return buyer.pi_username ?? '';
+};

--- a/test/utils/order.test.ts
+++ b/test/utils/order.test.ts
@@ -1,0 +1,51 @@
+import {
+  formatPiAmount,
+  getBuyerUsername,
+  getSellerName,
+} from '../../src/utils/order';
+
+describe('formatPiAmount', () => {
+  it('formats Mongo Decimal128 JSON values', () => {
+    expect(formatPiAmount({ $numberDecimal: '14' })).toBe('14');
+    expect(formatPiAmount({ $numberDecimal: 6 })).toBe('6');
+  });
+
+  it('formats plain numeric and string values', () => {
+    expect(formatPiAmount(14)).toBe('14');
+    expect(formatPiAmount(0.6000000000000001)).toBe('0.6000000000000001');
+    expect(formatPiAmount('6')).toBe('6');
+  });
+
+  it('returns an empty string for missing values', () => {
+    expect(formatPiAmount(null)).toBe('');
+    expect(formatPiAmount(undefined)).toBe('');
+    expect(formatPiAmount({})).toBe('');
+    expect(formatPiAmount({ $numberDecimal: null })).toBe('');
+  });
+});
+
+describe('getSellerName', () => {
+  it('returns the seller name when the seller is populated', () => {
+    expect(getSellerName({ name: 'Seller A' })).toBe('Seller A');
+  });
+
+  it('returns an empty string for missing or unpopulated sellers', () => {
+    expect(getSellerName(null)).toBe('');
+    expect(getSellerName(undefined)).toBe('');
+    expect(getSellerName('seller-id')).toBe('');
+    expect(getSellerName({})).toBe('');
+  });
+});
+
+describe('getBuyerUsername', () => {
+  it('returns the buyer username when the buyer is populated', () => {
+    expect(getBuyerUsername({ pi_username: 'alice' })).toBe('alice');
+  });
+
+  it('returns an empty string for missing or unpopulated buyers', () => {
+    expect(getBuyerUsername(null)).toBe('');
+    expect(getBuyerUsername(undefined)).toBe('');
+    expect(getBuyerUsername('buyer-id')).toBe('');
+    expect(getBuyerUsername({})).toBe('');
+  });
+});

--- a/test/utils/order.test.ts
+++ b/test/utils/order.test.ts
@@ -1,8 +1,4 @@
-import {
-  formatPiAmount,
-  getBuyerUsername,
-  getSellerName,
-} from '../../src/utils/order';
+import { formatPiAmount } from '../../src/utils/order';
 
 describe('formatPiAmount', () => {
   it('formats Mongo Decimal128 JSON values', () => {
@@ -21,31 +17,5 @@ describe('formatPiAmount', () => {
     expect(formatPiAmount(undefined)).toBe('');
     expect(formatPiAmount({})).toBe('');
     expect(formatPiAmount({ $numberDecimal: null })).toBe('');
-  });
-});
-
-describe('getSellerName', () => {
-  it('returns the seller name when the seller is populated', () => {
-    expect(getSellerName({ name: 'Seller A' })).toBe('Seller A');
-  });
-
-  it('returns an empty string for missing or unpopulated sellers', () => {
-    expect(getSellerName(null)).toBe('');
-    expect(getSellerName(undefined)).toBe('');
-    expect(getSellerName('seller-id')).toBe('');
-    expect(getSellerName({})).toBe('');
-  });
-});
-
-describe('getBuyerUsername', () => {
-  it('returns the buyer username when the buyer is populated', () => {
-    expect(getBuyerUsername({ pi_username: 'alice' })).toBe('alice');
-  });
-
-  it('returns an empty string for missing or unpopulated buyers', () => {
-    expect(getBuyerUsername(null)).toBe('');
-    expect(getBuyerUsername(undefined)).toBe('');
-    expect(getBuyerUsername('buyer-id')).toBe('');
-    expect(getBuyerUsername({})).toBe('');
   });
 });


### PR DESCRIPTION
This PR hardens the order UI against edge-case order payload shapes.

The reported **View Sent Orders** defect may be caused by an unexpected order payload shape, such as a missing/unpopulated `seller_id` or a non-standard amount value.  While we still need confirmation from an affected user’s browser console stack trace/API payload to prove the exact root cause, these guards are still worthwhile because the order model has continued to change and grow.

**[see commits]**